### PR TITLE
Literature up to 2012 (#11)

### DIFF
--- a/MYabrv.bib
+++ b/MYabrv.bib
@@ -1,4 +1,5 @@
 conference
+@String{AAAI = "Proc.\ Conf.\ on Artificial Intelligence (AAAI)"}
 @String{ABZ = "Proc.\ Int'l Conf.\ on Abstract State Machines, Alloy, B and Z (ABZ)"}
 @String{AOSD = "Proc.\ Int'l Conf.\ on Aspect-Oriented Software Development (AOSD)"}
 @String{APSEC = "Proc.\ Asia-Pacific Software Engineering Conference (APSEC)"}
@@ -15,8 +16,10 @@ conference
 @String{CBSOFT = "Proc.\ Brazilian Conf.\ Software: Theory and Practice (CBSoft)"}
 @String{COMPSAC = "Proc.\ on Computer Software and Applications Conf.\ (COMPSAC)"}
 @String{COORDINATION = "Proc.\ Int'l Conf.\ on Coordination Models and Languages (COORDINATION)"}
+@String{CPAIOR = "Proc.\ Int'l Conf.\ on Integration of Constraint Programming, Artificial Intelligence, and Operations Research (CPAIOR)"}
 @String{CP = "Proc.\ Int'l Conf.\ on Principles and Practice of Constraint Programming (CP)"}
 @String{CSMR = "Proc.\ Europ.\ Conf.\ on Software Maintenance and Reengineering (CSMR)"}
+@String{DAC = "Proc.\ Anual Conf.\ on Design Automation (DAC)"}
 @String{EASE = "Proc.\ Int'l Conf. on Evaluation Assessment in Software Engineering (EASE)"}
 @String{ECBS = "Proc.\ Int'l Conf.\ on Engineering of Computer-Based Systems (ECBS)"}
 @String{ECMDA = "Proc.\ Europ.\ Conf.\ on Model Driven Architecture - Foundations and Applications (ECMDA)"}
@@ -58,6 +61,7 @@ conference
 @String{IDPT = "Proc.\ World Conf.\ on Integrated Design and Process Technology (IDPT)"}
 @String{IFAC = "World Congress of the International Federation of Automatic Control (IFAC)"}
 @String{iFM = "Proc.\ World Conf.\ on Integrated Formal Methods (iFM)"}
+@String{IJCAI = "Proc.\ Int'l Joint Conf.\ on Artificial Intelligence (IJCAI)"}
 @String{IPISE = "Intentional Perspectives on Information Systems Engineering"}
 @String{Informatik = "Jahrestagung der Gesellschaft f{\"{u}}r Informatik"}
 @String{ITNG = "Proc.\ Inte'l Conf.\ on Information Technology: New Generations (ITNG)"}
@@ -78,6 +82,7 @@ conference
 @String{PPPJ = "Proc.\ Int'l Conf.\ on Principles and Practices of Programming on the Java Platform: Virtual Machines, Languages, and Tools (PPPJ)"}
 @String{PROFES = "Proc.\ of Int'l Conf.\ on Product Focused Software Process Improvement (PROFES)"}
 @String{Promise = "Proc.\ of Int'l Conf.\ on Predictive Models in Software Engineering (Promise)"}
+@String{QEST = "Proc.\ Int'l Conf.\ on Quantitative Evaluation of SysTems (QEST)"}
 @String{QoSA = "Proc.\ Int'l Conf.\ on Quality of Software Architectures (QoSA)"}
 @String{QSIC = "Proc.\ Int'l Conf.\ on Quality Software (QSIC)"}
 @String{RAMiCS = "Proc.\ Int'l Conf.\ on Relational and Algebraic Methods in Computer Science (RAMiCS)"}
@@ -87,6 +92,7 @@ conference
 @String{RISE = "Proc.\ Int'l Conf.\ on Rapid Integration of Software Engineering Techniques (RISE)"}
 @String{RV = "Proc.\ Int'l Conf.\ on Runtime Verification (RV)"}
 @String{SANER = "Proc.\ Int'l Conf.\ on Software Analysis, Evolution and Reengineering (SANER)"}
+@String{SAT = "Proc.\ Int'l Conf.\ on Theory and Applications of Satisfiability Testing (SAT)"}
 @String{SCAM = "Proc.\ Int'l Working Conf.\ on Source Code Analysis and Manipulation (SCAM)"}
 @String{SE = "Proc.\ Software Engineering (SE)"}
 @String{SEFM = "Proc.\ Int'l Conf.\ on Software Engineering and Formal Methods (SEFM)"}
@@ -98,9 +104,11 @@ conference
 @String{SLE = "Proc.\ Int'l Conf.\ on Software Language Engineering (SLE)"}
 @String{SOFTENG = "Proc.\ Conf.\ on Advances and Trends in Software Engineering (SOFTENG)"}
 @String{SOFSEM = "Proc.\ Conf.\ on Current Trends in Theory and Practice of Computer Science (SOFSEM)"}
+@String{SOMET = "Proc.\ Int'l Conf.\ on Intelligent Software Methodologies, Tools and Techniques (SOMET)"}
 @String{SPLC = "Proc.\ Int'l Systems and Software Product Line Conf.\ (SPLC)"}
 @String{SPLASH = "Proc.\ Int'l Conf.\ on Object-Oriented Programming Systems Languages and Applications Companion (SPLASH)"}
 @String{SSIRI = "Proc.\ Int'l Conf.\ on Secure System Integration and Reliability Improvement (SSIRI)"}
+@String{TACAS = "Proc.\ Int'l Conf.\ on Tools and Algorithms for the Construction and Analysis of Systems (TACAS)"}
 @String{TAP = "Proc.\ Int'l Conf.\ on Tests and Proofs (TAP)"}
 @String{TOOLSeurope = "Proc.\ Int'l Conf.\ Objects, Models, Components, Patterns (TOOLS EUROPE)"}
 @String{TOOLSpacific = "Proc.\ Int'l Conf.\ on Technology of Object-Oriented Languages and Systems (TOOLS)"}
@@ -112,9 +120,11 @@ conference
 
 workshop
 @String{AOAsia = "Proc.\ Asian Workshop on Aspect-Oriented Software Development (AOAsia)"}
+@String{AOSE = "Proc.\ Int'l Workshop on Agent-Oriented Software Engineering (AOSE)"}
 @String{APLE = "Proc.\ Int'l Workshop on Agile Product Line Engineering (APLE)"}
 @String{ASAS = "Proc.\ Workshop on Assurances for Self-Adaptive Systems (ASAS)"}
 @String{BigMDE = "Proc.\ of the Workshop on Scalability in Model Driven Engineering (BigMDE)"}
+@String{CFV = "Proc.\ Int'l Workshop on Constraints in Formal Verification (CFV)"}
 @String{CMA = "Proc.\ Int'l Workshop on Comparing Modeling Approaches (CMA)"}
 @String{ConfWS = "Proc.\ Configuration Workshop (ConfWS)"}
 @String{CVSM = "Proc.\ of the Workshop on Comparison and Versioning of Software Models (CVSM)"}
@@ -148,6 +158,7 @@ workshop
 @String{InnoSWDev = "Proc.\ Workshop on Innovative Software Development Methodologies and Practices (InnoSWDev)"}
 @String{IWCT = "Proc.\ Int'l Workshop on Combinatorial Testing (IWCT)"}
 @String{IWPC = "Proc.\ Int'l Workshop on Program Comprehension (IWPC)"}
+@String{IWPSE = "Proc.\ Int'l Workshop on Principles of Software Evolution"}
 @String{IW-SAPF = "Proc.\ Int'l Workshop on Software Architectures for Product Families (IW-SAPF)"}
 @String{IWSSD = "Proc.\ Int'l Workshop on Software Specification and Design (IWSSD)"}
 @String{REFINE = "Proc.\ Int'l Workshop on Refinement (REFINE)"}
@@ -179,8 +190,10 @@ symposium
 @String{FM = "Proc.\ Int'l Symposium on Formal Methods (FM)"}
 @String{FMCO = "Proc.\ Int'l Symposium on Formal Methods for Components and Objects (FMCO)"}
 @String{FME = "Proc.\ Int'l Symposium of Formal Methods Europe on Formal Methods for Increasing Software Productivity (FME)"}
+@String{FOCS = "Proc.\ IEEE Symposium on Foundations of Computer Science (FOCS)"}
 @String{FSE	= "Proc.\ Int'l Symposium on Foundations of Software Engineering (FSE)"}
 @String{HASE = "Proc.\ Int'l Symposium on High-Assurance Systems Engineering (HASE)"}
+@String{ISESE = "Proc.\ Int'l Symposium on Empirical Software Engineering (ISESE)"}
 @String{ISoLA = "Proc.\ Int'l Symposium on Leveraging Applications of Formal Methods, Verification and Validation (ISoLA)"}
 @String{ISORC = "Proc.\ Int'l Symposium on Object-Oriented Real-Time Distributed Computing (ISORC)"}
 @String{ISSRE = "Proc.\ Int'l Symposium on Software Reliability Engineering (ISSRE)"}
@@ -217,6 +230,7 @@ journal
 @String{FMSD = "Formal Methods in System Design"}
 @String{IBMSJ = "IBM Syst. J."}
 @String{IC = "J.\ Information and Computation"}
+@String{IJC = "INFORMS J.\ on Computing"}
 @String{IJAST = "Int'l J.\ Applied Science and Technology (IJAST)"}
 @String{IJCSI = "Int'l J.\ Computer Science Issues (IJCSI)"}
 @String{IJPE = "Int'l J.\ Production Economics"}
@@ -228,6 +242,7 @@ journal
 @String{JAR = "J.\ Autom.\ Reason."}
 @String{JAIR = "J.\ Artificial Intelligence Research (JAIR)"}
 @String{JBCS = "J.\ Brazilian Computer Society (JBCS)"}
+@String{JEA = "ACM J.\ of Experimental Algorithmics (JEA)"}
 @String{JLAMP = "J.\ Logic and Algebraic Methods in Programming (JLAMP)"}
 @String{JLAP = "J.\ Logic and Algebraic Programming (JLAP)"}
 @String{JOM = "J.\ Operations Management (JOM)"}
@@ -246,6 +261,7 @@ journal
 @String{OSR = "ACM SIGOPS Operating Systems Review"}
 @String{PPL = "Parallel Processing Letters"}
 @String{PNAS = "Proc.\ of the National Academy of Sciences of the United States of America (PNAS)"}
+@String{QREI = "Quality and Reliability Engineering International"}
 @String{REJ = "Requirements Engineering"}
 @String{SCP = "Science of Computer Programming (SCP)"}
 @String{SEN = "SIGSOFT Software Engineering Notes"}
@@ -299,6 +315,10 @@ publisher and address
 
 @String{Fraunhofer = "Fraunhofer IRB Verlag"}
 
+@String{GI = "Gesellschaft f{\"u}r Informatik"}
+	@String{Bonn = "Bonn, Germany"}
+	@String{Singapore = "Singapore, Singapore"}
+
 @String{IBFI = "IBFI"}
 
 @String{IBM = "IBM Corp.\"}
@@ -309,12 +329,10 @@ publisher and address
 	@String{Miami = "Miami, FL, USA"}
 	@String{Montreal = "Montreal, Quebec, Canada"}
 	@String{LosAlamitos = "Los Alamitos, CA, USA"}
-	@String{GI = "Gesellschaft f{\"u}r Informatik"}
-	@String{Bonn = "Bonn, Germany"}
-	@String{Singapore = "Singapore, Singapore"}
 
 @String{INFORMS = "INFORMS"}
  	@String{Catonsville = "Catonsville, USA"}
+ 	@String{Linthium = "Institute for Operations Research and the Management Sciences (INFORMS), Linthicum, MD, USA"}
 
 @String{IOS = "IOS Press"}
 

--- a/MYshort.bib
+++ b/MYshort.bib
@@ -16,6 +16,7 @@ conference
 @String{COMPSAC = "COMPSAC"}
 @String{COORDINATION = "COORDINATION"}
 @String{CP = "CP"}
+@String{CPAIOR = "CPAIOR"}
 @String{CSMR = "CSMR"}
 @String{EASE = "EASE"}
 @String{ECBS = "ECBS"}
@@ -98,9 +99,11 @@ conference
 @String{SLE = "SLE"}
 @String{SOFTENG = "SOFTENG"}
 @String{SOFSEM = "SOFSEM"}
+@String{SOMET = "SOMET"}
 @String{SPLC = "SPLC"}
 @String{SPLASH = "SPLASH"}
 @String{SSIRI = "SSIRI"}
+@String{TACAS = "TACAS"}
 @String{TAP = "TAP"}
 @String{TC = "TC"}
 @String{TOOLSeurope = "TOOLS Europe"}
@@ -216,6 +219,7 @@ journal
 @String{FMSD = "FMSD"}
 @String{IBMSJ = "IBM Syst. J."}
 @String{IC = "IC"}
+@String{IJC = "IJC"}
 @String{IJAST = "IJAST"}
 @String{IJCSI = "IJCSI"}
 @String{IJPE = "IJPE"}
@@ -227,6 +231,7 @@ journal
 @String{JAR = "JAR"}
 @String{JAIR = "JAIR"}
 @String{JBCS = "JBCS"}
+@String{JEA = "JEA"}
 @String{JLAMP = "JLAMP"}
 @String{JLAP = "JLAP"}
 @String{JOM = "JOM"}
@@ -245,6 +250,7 @@ journal
 @String{OSR = "OSR"}
 @String{PPL = "PPL"}
 @String{PNAS = "PNAS"}
+@String{QREI = "QREI"}
 @String{REJ = "REJ"}
 @String{SCP = "SCP"}
 @String{SEN = "SEN"}
@@ -299,6 +305,10 @@ publisher and address
 
 @String{Fraunhofer = "Fraunhofer IRB Verlag"}
 
+@String{GI = "Gesellschaft f{\"u}r Informatik"}
+	@String{Bonn = "Bonn, Germany"}
+	@String{Singapore = "Singapore, Singapore"}
+	
 @String{IBFI = "IBFI"}
 
 @String{IBM = "IBM Corp.\"}
@@ -309,12 +319,10 @@ publisher and address
 	@String{Miami = "Miami, FL, USA"}
 	@String{Montreal = "Montreal, Quebec, Canada"}
 	@String{LosAlamitos = "Los Alamitos, CA, USA"}
-	@String{GI = "Gesellschaft f{\"u}r Informatik"}
-	@String{Bonn = "Bonn, Germany"}
-	@String{Singapore = "Singapore, Singapore"}
 
 @String{INFORMS = "INFORMS"}
  	@String{Catonsville = "Catonsville, USA"}
+ 	@String{Linthium = "Institute for Operations Research and the Management Sciences (INFORMS), Linthicum, MD, USA"}
 
 @String{IOS = "IOS Press"}
 
@@ -349,9 +357,9 @@ publisher and address
 	 @String{Secaucus = "Secaucus, NJ, USA"}
 
 @String{VLDB = "VLDB Endowment"}
+
 @String{Wiley = "John Wiley & Sons"}
  	@String{WileyMonterey = "Monterey, CA, USA"} % This is the address of the responsible editors
-
 
 other
 @String{MIT = "MIT"}

--- a/literature.bib
+++ b/literature.bib
@@ -303,7 +303,7 @@
 	address = NY,
 	tt-tags = {Product Sampling},
 	tc-tags = {classified by Thomas,testing,sample-based analysis,specification independent,implementation independent,program,subsumed by none},
-	sampling-tags = {name=YASA,feature model,expert knowledge,greedy,t-wise coverage,evaluation,sampling efficiency,testing efficiency,open-source tool,testing,compared to Chvatal/ICPL/IncLing,usage of FeatureIDE/Sat4J,SAT,JS20},
+	sampling-tags = {name = YASA,feature model,expert knowledge,greedy,t-wise coverage,evaluation,sampling efficiency,testing efficiency,open-source tool,testing,compared to Chvatal/ICPL/IncLing,usage of FeatureIDE/Sat4J,SAT,JS20},
 	month = FEB,
 	year = 2020
 }
@@ -365,22 +365,22 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% 2019 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 @inproceedings{AFH+:SODA19,
-	author={Antoniadis, Antonios and Fleszar, Krzysztof and Hoeksma, Ruben and Schewior, Kevin},
-	title={{A PTAS for Euclidean TSP With Hyperplane Neighborhoods}},
-	publisher=SIAM,
+	author = {Antoniadis, Antonios and Fleszar, Krzysztof and Hoeksma, Ruben and Schewior, Kevin},
+	title = {{A PTAS for Euclidean TSP With Hyperplane Neighborhoods}},
+	publisher = SIAM,
 	address = Philadelphia,
-	booktitle=SODA,
-	location={San Diego, CA, USA},
-	pages={1089--1105},
-	month=JAN,
-	year=2019,
-	organization=SIAM,
+	booktitle = SODA,
+	location = {San Diego, CA, USA},
+	pages = {1089--1105},
+	month = JAN,
+	year = 2019,
+	publisher = SIAM,
 	doi = {10.1137/1.9781611975482.67}
 }
 
 @article{G:SIGACT19,
 	author = {Gasarch, William I.},
-	title = {{Guest Column: The Third P=?NP Poll}},
+	title = {{Guest Column: The Third P = ?NP Poll}},
 	year = {2019},
 	publisher = ACM,
 	address = NY,
@@ -394,29 +394,29 @@
 }
 
 @inproceedings{JS:CAV19,
-	title={{Q3B: An Efficient BDD-based SMT Solver for Quantified Bit-Vectors}},
-	author={Jon{\'a}{\v{s}}, Martin and Strej{\v{c}}ek, Jan},
-	publisher=Springer,
+	title = {{Q3B: An Efficient BDD-based SMT Solver for Quantified Bit-Vectors}},
+	author = {Jon{\'a}{\v{s}}, Martin and Strej{\v{c}}ek, Jan},
+	publisher = Springer,
 	address = BerlinHeidelberg,
 	location = NY,
-	booktitle=CAV,
-	pages={64--73},
-	month=JUL,
-	year=2019,
-	doi={10.1007/978-3-030-25543-5_4}
+	booktitle = CAV,
+	pages = {64--73},
+	month = JUL,
+	year = 2019,
+	doi = {10.1007/978-3-030-25543-5_4}
 }
 
 %see https://ctan.org/tex-archive/macros/latex/contrib/IEEEtran/bibtex
 @patent{SA:PATENT19,
-	title={{Product Configuration}},
-	author={Subbarayan, Sathia Moorthy and Andersen, Henrik Reif},
-	assignee={Configit A/S},
-	address={Copenhagen, Denmark},
-	year=2019,
-	month=MAY,
-	number="10303808",
-	nationality={U.S.},
-	note={US Patent 10,303,808}
+	title = {{Product Configuration}},
+	author = {Subbarayan, Sathia Moorthy and Andersen, Henrik Reif},
+	assignee = {Configit A/S},
+	address = {Copenhagen, Denmark},
+	year = 2019,
+	month = MAY,
+	number = "10303808",
+	nationality = {U.S.},
+	note = {US Patent 10,303,808}
 }
 
 @inproceedings{TSG+:VR19,
@@ -512,7 +512,7 @@
   year = 2019,
   doi = {10.1109/ICST.2019.00032},
   sampling-tags = {evaluation, open-source tool, sampling efficiency, effectiveness, testing, non-functional properties, compares QuickSampler/UniGen, JS20},
-  organization = IEEE,
+  publisher = IEEE,
   address = Piscataway 
 }
 
@@ -538,7 +538,7 @@
   pages = {1084--1094},
   doi = {10.1109/ICSE.2019.00112},
   isbn = {978-1-7281-0869-8},
-  sampling-tags = {name=Distance-Based Search, feature model, population-based search, semi-automatic search, evaluation, effectiveness, open-source tool, non-functional properties, compares Distance-Based Search/random sampling/higher-order heuristic/hot-spot heuristic, SPLConqueror, Z3, JS20},
+  sampling-tags = {name = Distance-Based Search, feature model, population-based search, semi-automatic search, evaluation, effectiveness, open-source tool, non-functional properties, compares Distance-Based Search/random sampling/higher-order heuristic/hot-spot heuristic, SPLConqueror, Z3, JS20},
   publisher = IEEE,
   address = Piscataway,
   year = 2019
@@ -580,7 +580,7 @@
 	tt-tags = {Kconfig},
 	tt-tags = {KConfig,Product Sampling},
 	tc-tags = {},
-	sampling-tags = {name=Smarch, feature model, local search, no coverage guarantee, evaluation, sampling efficiency, effectiveness, open-source tool, non-functional properties, JS20},
+	sampling-tags = {name = Smarch, feature model, local search, no coverage guarantee, evaluation, sampling efficiency, effectiveness, open-source tool, non-functional properties, JS20},
 	year = 2019
 }
 
@@ -597,7 +597,7 @@
 	address = NY,
 	tt-tags = {KConfig,Product Sampling},
 	tc-tags = {},
-	sampling-tags = {name=Smarch+BBPF, feature model, local search, no coverage guarantee, evaluation, sampling efficiency, open-source tool, non-functional properties, JS20},
+	sampling-tags = {name = Smarch+BBPF, feature model, local search, no coverage guarantee, evaluation, sampling efficiency, open-source tool, non-functional properties, JS20},
 	year = 2019
 }
 
@@ -658,7 +658,7 @@
 	pages = {613--633},
 	tt-tags = {SPL Specification,SPL Testing,SPL Coverage},
 	tc-tags = {classified by Thomas,testing,sample-based analysis,implementation independent,family-based specification,program,tool,evaluation,subsumed by none},
-	sampling-tags = {name=minimum/maximum-delay testing,feature model,test artifacts,greedy,specification coverage,sampling efficiency,testing efficiency,available tool,evaluation,non-functional properties,IMITATOR,usage of CoPTA/Uppaal/Z3,ILP,SMT,featured timed automata,infinite configuration space},
+	sampling-tags = {name = minimum/maximum-delay testing,feature model,test artifacts,greedy,specification coverage,sampling efficiency,testing efficiency,available tool,evaluation,non-functional properties,IMITATOR,usage of CoPTA/Uppaal/Z3,ILP,SMT,featured timed automata,infinite configuration space},
 	year = 2019
 }
 
@@ -1000,40 +1000,40 @@
 }
 
 @article{CJ:TALG18,
-	title={{Reducing Curse of Dimensionality: Improved PTAS for TSP (with Neighborhoods) in Doubling Metrics}},
-	author={Chan, T.-H. Hubert and Jiang, Shaofeng H.-C.},
-	journal= TALG,
-	volume={14},
-	number={1},
+	title = {{Reducing Curse of Dimensionality: Improved PTAS for TSP (with Neighborhoods) in Doubling Metrics}},
+	author = {Chan, T.-H. Hubert and Jiang, Shaofeng H.-C.},
+	journal = TALG,
+	volume = {14},
+	number = {1},
 	pages = {9:1--9:18},
-	year=2018,
+	year = 2018,
 	month = JAN,
-	publisher=ACM,
-	address=NY,
+	publisher = ACM,
+	address = NY,
 	doi = {10.1145/3158232}
 }
 
 @incollection{B18,
-	author    = {Bryant, Randal E.},
-	title     = {{Binary Decision Diagrams}},
+	author = {Bryant, Randal E.},
+	title = {{Binary Decision Diagrams}},
 	booktitle = {Handbook of Model Checking},
-	year      = 2018,
+	year = 2018,
 	publisher = Springer,
-	address   = Cham,
-	pages     = {191--217},
-	doi       = {10.1007/978-3-319-10575-8\_7},
+	address = Cham,
+	pages = {191--217},
+	doi = {10.1007/978-3-319-10575-8\_7},
 }
 
 @patent{SAH:PATENT18,
-	title={{Product Configuration}},
-	author={Subbarayan, Sathia Moorthy and Andersen, Henrik Reif and Hulgaard, Henrik},
-	assignee={Configit A/S},
-	address={Copenhagen, Denmark},
-	year=2018,
-	month=AUG,
-	number="10049396",
-	nationality={U.S.},
-	note={US Patent 10,049,396}
+	title = {{Product Configuration}},
+	author = {Subbarayan, Sathia Moorthy and Andersen, Henrik Reif and Hulgaard, Henrik},
+	assignee = {Configit A/S},
+	address = {Copenhagen, Denmark},
+	year = 2018,
+	month = AUG,
+	number = "10049396",
+	nationality = {U.S.},
+	note = {US Patent 10,049,396}
 }
 
 @inproceedings{ABAB:ICSME18,
@@ -1066,7 +1066,7 @@
 
 @article{WBC:SCP18,
 	title = {{Improving Custom-Tailored Variability Mining Using Outlier and Cluster Detection}},
-	author={Wille, David and Babur, {\"O}nder and Cleophas, Loek and Seidl, Christoph and van den Brand, Mark and Schaefer, Ina},
+	author = {Wille, David and Babur, {\"O}nder and Cleophas, Loek and Seidl, Christoph and van den Brand, Mark and Schaefer, Ina},
 	journal = SCP,
 	volume = {163},
 	pages = {62--84},
@@ -1453,7 +1453,7 @@
 	keywords = {Configurable systems, Model selection, Parameter tuning, Performance prediction, Regression},
 	tt-tags = {SPL Non-Functional Properties},
 	tc-tags = {classified by Thomas,performance analysis,sample-based analysis,specification independent,implementation independent,program,subsumed by none},
-	sampling-tags = {name=random sampling,greedy,feature model,no coverage guarantee,testing efficiency,open-source tool,DECART,evaluation,non-functional properties,SPLC18},
+	sampling-tags = {name = random sampling,greedy,feature model,no coverage guarantee,testing efficiency,open-source tool,DECART,evaluation,non-functional properties,SPLC18},
 	month = JUN,
 	year = 2018
 }
@@ -1489,7 +1489,7 @@
 	keywords = {Bugs, Linux, feature interactions, software variability},
 	tt-tags = {Feature Interaction},
 	tc-tags = {analysis method undefined,sample-based analysis,implementation independent,no tool,evaluation},
-	sampling-tags = {name=one-disabled,greedy,feature model,no coverage guarantee,evaluation,testing efficiency,effectiveness,evaluated with real faults,testing,SPLC18},
+	sampling-tags = {name = one-disabled,greedy,feature model,no coverage guarantee,evaluation,testing efficiency,effectiveness,evaluated with real faults,testing,SPLC18},
 	month = JAN,
 	year = 2018
 }
@@ -1566,8 +1566,8 @@
   pages = {61--71},
   doi = {10.1145/3106237.3106273},
   month = AUG,
-  sampling-tags = {name=NRS, feature model, local search, evaluation, effectiveness, non-functional properties, unavailable tool, JS20},
-  sampling2-tags = {name=SRS, feature model, local search, evaluation, effectiveness, non-functional properties, unavailable tool, JS20},
+  sampling-tags = {name = NRS, feature model, local search, evaluation, effectiveness, non-functional properties, unavailable tool, JS20},
+  sampling2-tags = {name = SRS, feature model, local search, evaluation, effectiveness, non-functional properties, unavailable tool, JS20},
   year = 2017
 }
 
@@ -1585,7 +1585,7 @@
 @mastersthesis{G17,
 	author = {G{\"u}nther, Timo},
 	title = {{Explaining Satisfiability Queries for Software Product Lines}},
-	year = 	2017,
+	year = 2017,
 	address = {Germany},
 	school = {TU Braunschweig},
 	keywords = {software product lines, explanations, feature modeling, configuration files, preprocessing files, Antenna, C preprocessor, Java, Softwareproduktlinien, Erkl{\"a}rungen, Feature-Modellierung, Konfigurationsdateien, Pr{\"a}prozessordateien, C-Pr{\"a}prozessor},
@@ -1697,7 +1697,7 @@
 	address = Piscataway,
 	tt-tags = {SPL Testing},
 	tc-tags = {classified by Thomas,testing,sample-based analysis,specification independent,implementation independent,program,subsumed by none},
-	sampling-tags = {name=SPEA2-HH/IBEA-HH,compared to MOEA/D-DRA/NSGA-II,usage of CombTestWeb/FMTS/FaMa,feature model,population-based search,no coverage guarantee,sampling efficiency,effectiveness,unavailable tool,evaluation,testing,feature-model mutation,SPLC18},
+	sampling-tags = {name = SPEA2-HH/IBEA-HH,compared to MOEA/D-DRA/NSGA-II,usage of CombTestWeb/FMTS/FaMa,feature model,population-based search,no coverage guarantee,sampling efficiency,effectiveness,unavailable tool,evaluation,testing,feature-model mutation,SPLC18},
 	month = MAY,
 	year = 2017
 } 
@@ -1745,7 +1745,7 @@
 	keywords = {Hyper-Heuristics, Search-Based Software Engineering, Software Product Line Testing},
 	tt-tags = {SPL Testing},
 	tc-tags = {classified by Thomas,testing,sample-based analysis,specification independent,implementation independent,program,subsumed by none},
-	sampling-tags = {name=Filho's generated MOEAs,compared to NSGAII/NSGAII-HH,usage of CombTestWeb/FMTS,feature model,population-based search,automatic selection,no coverage guarantee,testing efficiency,effectiveness,unavailable tool,evaluation,testing,feature-model mutation,SPLC18},
+	sampling-tags = {name = Filho's generated MOEAs,compared to NSGAII/NSGAII-HH,usage of CombTestWeb/FMTS,feature model,population-based search,automatic selection,no coverage guarantee,testing efficiency,effectiveness,unavailable tool,evaluation,testing,feature-model mutation,SPLC18},
 	year = 2017
 } 
 
@@ -2198,6 +2198,97 @@
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% 2016 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
+@phdthesis{K16,
+	title = {{The Role of Complex Constraints in Feature Modeling}},
+	author = {Kn{\"u}ppel, Alexander},
+	school = {TU Braunschweig},
+	address = {Germany},
+	year = 2016
+}
+
+@article{KR:QREI16,
+	title = {{An Optimal Solution for Test Case Generation Using ROBDD Graph and PSO Algorithm}},
+	author = {Kalaee, Akram and Rafe, Vahid},
+	journal = QREI,
+	volume = {32},
+	number = {7},
+	pages = {2263--2279},
+	year = 2016,
+	publisher = Wiley,
+	address = WileyMonterey
+}
+
+@article{TS:JEA16,
+	author = {Takahisa Toda and Takehide Soh},
+	title = {{Implementing Efficient All Solutions SAT Solvers}},
+	journal = JEA,
+	volume = {21},
+	number = {1},
+	month = NOV,
+	pages = {1.12:1--1.12:44},
+	doi = {10.1145/2975585},
+	publisher = ACM,
+	address = NY,
+	year = 2016,
+}
+
+@inproceedings{SWS:Modellierung16,
+	title = {{A Software Product Line of Feature Modeling Notations and Cross-Tree Constraint Languages}},
+	author = {Seidl, Christoph and Winkelmann, Tim and Schaefer, Ina},
+	booktitle = Modellierung,
+	editor = {Andreas Oberweis and Ralf H. Reussner},
+	pages = {157--172},
+	publisher = GI,
+	address = Bonn,
+	year = 2016,
+} 
+
+@phdthesis{P16:UNED,
+	title = {{BDD Algorithms to Perform Hard Analysis Operations on Variability Models}},
+	author = {P{\'e}rez Morago, H{\'e}ctor Jos{\'e}},
+	school = {Universidad Nacional de Educaci{\'o}n a Distancia},
+	address = {{Spain}},
+	year = 2016
+}
+
+@masterthesis{A16,
+	title = {{Explaining Defects and Identifying Dependencies in Interrelated Feature Models}},
+	author = {Ananieva, Sofia},
+	school = {TU Braunschweig},
+	address = {Germany},
+	month = SEP,
+	year = 2016
+}
+
+@inproceedings{HPF+:SOMET16,
+	title = {{Binary Decision Diagram Algorithms to Perform Hard Analysis Operations on Variability Models}},
+	author = {Heradio, Ruben and P{\'e}rez-Morago, H{\'e}ctor Jos{\'e} and Fern{\'a}ndez-Amor{\'o}s, David and Bean, Roberto and Cabrerizo, Francisco Javier and Cerrada, Carlos and Herrera-Viedma, Enrique},
+	booktitle = SOMET,
+	publisher = IOS,
+	pages = {139--154},
+	year = 2016
+}
+
+@book{BCHH16,
+	title = {{Decision Diagrams for Optimization}},
+	author = {David Bergman and Andr{\'{e}} A. Cir{\'{e}} and Willem{-}Jan van Hoeve and John N. Hooker},
+  	series = {Artificial Intelligence: Foundations, Theory, and Algorithms},
+	publisher = Springer,
+	address = BerlinHeidelberg,
+	year = 2016,
+}
+
+@article{BCHH:IJC16,
+	title = {{Discrete Optimization with Decision Diagrams}},
+	author = {Bergman, David and Cir{\'e}, Andre A and van Hoeve, Willem-Jan and Hooker, John N.},
+	journal = IJC,
+	volume = {28},
+	number = {1},
+	pages = {47--66},
+	publisher = INFORMS,
+	year = 2016
+}
+
 @inproceedings{HHD:SRDS16,
 	author = {Franz J. Hauck and Gerhard Habiger and J{\"{o}}rg Domaschka},
 	title = {{UDS: A Novel and Flexible Scheduling Algorithm for Deterministic Multithreading}},
@@ -2360,7 +2451,7 @@
 
 @article{BFGM:JLAMP16,
 	author = {Maurice H. ter Beek and Alessandro Fantechi and Stefania Gnesi and Franco Mazzanti},
-	title ={{Modelling and Analysing Variability in Product Families: Model Checking of Modal Transition Systems with Variability Constraints}},
+	title = {{Modelling and Analysing Variability in Product Families: Model Checking of Modal Transition Systems with Variability Constraints}},
 	journal = JLAMP,
 	volume = 85,
 	number = 2,
@@ -2445,7 +2536,7 @@
 	doi = {10.1186/s40411-016-0030-9},
 	tt-tags = {SPL Testing},
 	tc-tags = {classified by Thomas,testing,sample-based analysis,specification independent,implementation independent,program,subsumed by none},
-	sampling-tags = {name=Matnei-Filho's algorithm,usage of FMTS/FaMa/AETG,feature model,population-based search,automatic selection,no coverage guarantee,testing efficiency,effectiveness,unavailable tool,evaluation,testing,feature-model mutation,SPLC18},
+	sampling-tags = {name = Matnei-Filho's algorithm,usage of FMTS/FaMa/AETG,feature model,population-based search,automatic selection,no coverage guarantee,testing efficiency,effectiveness,unavailable tool,evaluation,testing,feature-model mutation,SPLC18},
 	month = JUL,
 	year = 2016
 }
@@ -2460,7 +2551,7 @@
 	address = Piscataway,
 	tt-tags = {SPL Testing},
 	tc-tags = {classified by Thomas,testing,sample-based analysis,specification independent,implementation independent,program,subsumed by none},
-	sampling-tags = {name=MOEA/D-DRA,usage of CombTestWeb/FMTS,feature model,population-based search,no coverage guarantee,effectiveness,unavailable tool,evaluation,testing,feature-model mutation,SPLC18},
+	sampling-tags = {name = MOEA/D-DRA,usage of CombTestWeb/FMTS,feature model,population-based search,no coverage guarantee,effectiveness,unavailable tool,evaluation,testing,feature-model mutation,SPLC18},
 	month = JUL,
 	year = 2016
 }
@@ -2775,7 +2866,7 @@
 	address = NY,
 	tt-tags = {SPL Testing,FeatureIDE},
 	tc-tags = {},
-	sampling-tags = {name=IncLing,compared to CASA/Chvatal/ICPL/IPOG/random sampling,feature model,expert knowledge,greedy,semi-automatic selection,automatic selection,pair-wise coverage,sampling efficiency,testing efficiency,effectiveness,open-source tool,evaluation,testing,SPLC18},
+	sampling-tags = {name = IncLing,compared to CASA/Chvatal/ICPL/IPOG/random sampling,feature model,expert knowledge,greedy,semi-automatic selection,automatic selection,pair-wise coverage,sampling efficiency,testing efficiency,effectiveness,open-source tool,evaluation,testing,SPLC18},
 	keywords = {Software product lines, combinatorial interaction testing, model-based testing, sampling},
 	month = OCT,
 	year = 2016
@@ -2794,7 +2885,7 @@
 	address = NY,
 	tt-tags = {SPL Testing,FeatureIDE},
 	tc-tags = {},
-	sampling-tags = {name=user-defined configurations,tool support includes also random sampling/CASA/Chvatal/ICPL/IncLing,feature model,expert knowledge,manual selection,feature-wise coverage,open-source tool,FeatureIDE,testing,type checking,SPLC18},
+	sampling-tags = {name = user-defined configurations,tool support includes also random sampling/CASA/Chvatal/ICPL/IncLing,feature model,expert knowledge,manual selection,feature-wise coverage,open-source tool,FeatureIDE,testing,type checking,SPLC18},
 	keywords = {Prioritization, T-Wise Sampling, Testing},
 	month = OCT,
 	year = 2016
@@ -2881,8 +2972,8 @@
 	acmid = {2884793},
 	tt-tags = {Sampling,Survey},
 	tc-tags = {analysis method undefined,sample-based analysis,implementation independent,tool,evaluation},
-	sampling-tags = {name=one-enabled,greedy,feature model,no coverage guarantee,open-source tool,evaluation,testing efficiency,effectiveness,compared to ICPL/configuration coverage/one-disabled/random sampling,combinations evaluated,evaluated with real faults,testing,SPLC18},
-	sampling2-tags = {name=most-enabled-disabled,greedy,feature model,no coverage guarantee,open-source tool,evaluation,testing efficiency,effectiveness,compared to ICPL/configuration coverage/one-disabled/random sampling,combinations evaluated,evaluated with real faults,testing,SPLC18},
+	sampling-tags = {name = one-enabled,greedy,feature model,no coverage guarantee,open-source tool,evaluation,testing efficiency,effectiveness,compared to ICPL/configuration coverage/one-disabled/random sampling,combinations evaluated,evaluated with real faults,testing,SPLC18},
+	sampling2-tags = {name = most-enabled-disabled,greedy,feature model,no coverage guarantee,open-source tool,evaluation,testing efficiency,effectiveness,compared to ICPL/configuration coverage/one-disabled/random sampling,combinations evaluated,evaluated with real faults,testing,SPLC18},
 	publisher = ACM,
 	address = NY,
 	year = 2016
@@ -3263,6 +3354,7 @@
 	year = 2016
 }
 
+% Warning: The phdthesis by P{\'e}rez is found P16:UNED
 @mastersthesis{P16,
 	author = {Tristan Pfofe},
 	title = {{Automating the Synchronization of Software Variants}},
@@ -3292,6 +3384,25 @@
 }
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% 2015 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+@inproceedings{PyEDA15,
+	author = {Chris Drake},
+	title = {{PyEDA: Data Structures and Algorithms for Electronic Design Automation}},
+	booktitle = {{Proc.\ Conf.\ on Python in Science (SciPy)}},
+  	pages = {25--30},
+	editor = {Kathryn Huff and James Bergstra},
+	year = 2015,
+}
+
+@inproceedings{DP:TACAS15,
+	title = {{Sylvan: Multi-Core Decision Diagrams}},
+	author = {{van Dijk}, Tom and {van de Pol}, Jaco},
+	booktitle = TACAS,
+	pages = {677--691},
+	year = 2015,
+	publisher = Springer,
+	address = Cham
+}
 
 @book{So15, % S15 already taken
 	author = {Sommerville, Ian},
@@ -3483,7 +3594,7 @@
 	doi = {10.1109/SBES.2015.17},
 	tt-tags = {SPL Testing},
 	tc-tags = {classified by Thomas,testing,sample-based analysis,specification independent,implementation independent,program,subsumed by MFV:JSERD16},
-	sampling-tags = {name=Matnei-Filho's algorithm,usage of FMTS/FaMa/AETG,feature model,population-based search,automatic selection,no coverage guarantee,testing efficiency,effectiveness,unavailable tool,evaluation,testing,feature-model mutation,SPLC18,subsumed by MFV:JSERD16},
+	sampling-tags = {name = Matnei-Filho's algorithm,usage of FMTS/FaMa/AETG,feature model,population-based search,automatic selection,no coverage guarantee,testing efficiency,effectiveness,unavailable tool,evaluation,testing,feature-model mutation,SPLC18,subsumed by MFV:JSERD16},
 	publisher = IEEE,
 	address = Washington,
 	month = SEP,
@@ -3514,7 +3625,7 @@
 	acmid = {2916264},
 	publisher = IEEE,
 	address = Washington,
-	sampling-tags = {name=feature-frequency heuristic,compared to pair-wise/3-wise,feature model,greedy,automatic selection,feature-wise coverage,testing efficiency,effectiveness,open-source tool,evaluation,non-functional properties,SPLC18},
+	sampling-tags = {name = feature-frequency heuristic,compared to pair-wise/3-wise,feature model,greedy,automatic selection,feature-wise coverage,testing efficiency,effectiveness,open-source tool,evaluation,non-functional properties,SPLC18},
 	year = 2015
 }
 
@@ -3609,9 +3720,9 @@
 
 @inproceedings{useDBW:SCP18,
 	author = {Aleksandar S. Dimovski and Claus Brabrand and Andrzej W{\k{a}}sowski},
-	title =	{{Variability Abstractions: Trading Precision for Speed in Family-Based Analyses}},
-	booktitle =	ECOOP,
-	pages =	{247--270},
+	title = {{Variability Abstractions: Trading Precision for Speed in Family-Based Analyses}},
+	booktitle = ECOOP,
+	pages = {247--270},
 	series = {Leibniz International Proceedings in Informatics (LIPIcs)},
 	ISBN = {978-3-939897-86-6},
 	ISSN = {1868-8969},
@@ -3619,7 +3730,7 @@
 	editor = {John Tang Boyland},
 	URN = {urn:nbn:de:0030-drops-52253},
 	doi = {http://dx.doi.org/10.4230/LIPIcs.ECOOP.2015.247},
-	publisher =	SchlossDagstuhl,
+	publisher = SchlossDagstuhl,
 	address = Dagstuhl,
 	tt-tags = {},
 	tc-tags = {data-flow analysis,family-based analysis,preprocessor,family-based implementation,domain-independent specification,source code,tool,evaluation,subsumed by DBW:SCP18},
@@ -3761,8 +3872,8 @@
 	title = {{Mapping the Design Space of Textual Variability Modeling Languages: A Refined Analysis}},
 	journal = STTT,
 	issn = {1433-2779},
-	volume={17},
-	number={5},
+	volume = {17},
+	number = {5},
 	doi = {10.1007/s10009-014-0362-x},
 	pages = {559-584},
 	publisher = Springer,
@@ -3861,7 +3972,7 @@
 	isbn = {978-1-4503-3686-4},
 	location = {Pittsburgh, PA, USA},
 	pages = {149--160},
-	url = {https://dl.acm.org/citation.cfm?id=2814263},
+	url = {https://dl.acm.org/citation.cfm?id = 2814263},
 	acmid = {2814263},
 	publisher = ACM,
 	address = NY,
@@ -3883,7 +3994,7 @@
 	address = NY,
 	tt-tags = {SPL Testing,Feature Modeling},
 	tc-tags = {},
-	sampling-tags = {name=feature-diagram mutation,feature model,greedy,no coverage guarantee,sampling efficiency,testing efficiency,effectiveness,available tool,evaluation,no prioritization,testing,compared to ICPL,feature-model mutation,SPLC18},
+	sampling-tags = {name = feature-diagram mutation,feature model,greedy,no coverage guarantee,sampling efficiency,testing efficiency,effectiveness,available tool,evaluation,no prioritization,testing,compared to ICPL,feature-model mutation,SPLC18},
 	year = 2015
 } 
 
@@ -3902,7 +4013,7 @@
 
 
 @inproceedings{LLL+:SPLC15,
- author ={Lachmann,Remo and  Lity, Sascha  and Lischke, Sabrina and   Beddig, Simon  and Schulze, Sandro  and Schaefer, Ina},
+ author = {Lachmann,Remo and  Lity, Sascha  and Lischke, Sabrina and   Beddig, Simon  and Schulze, Sandro  and Schaefer, Ina},
 	title = {{Delta-Oriented Test Case Prioritization for Integration Testing of Software Product Lines}},
 	booktitle = SPLC,
 	isbn = {978-1-4503-3613-0},
@@ -3924,7 +4035,7 @@
 	publisher = IEEE,
 	tt-tags = {},
 	tc-tags = {},
-	sampling-tags = {name=distinguishing configurations,compared to pairwise sampling/all valid configurations,feature model,greedy,automatic selection,no coverage guarantee,sampling efficiency,testing efficiency,effectiveness,unavailable tool,evaluation,testing,type checking,feature-model mutation,SPLC18},
+	sampling-tags = {name = distinguishing configurations,compared to pairwise sampling/all valid configurations,feature model,greedy,automatic selection,no coverage guarantee,sampling efficiency,testing efficiency,effectiveness,unavailable tool,evaluation,testing,type checking,feature-model mutation,SPLC18},
 	month = APR,
 	year = 2015
 }
@@ -3940,16 +4051,16 @@
 }
 
 @article{SSR:sosym15,
-	author={S\'anchez, AnaB. and Segura, Sergio and Parejo, Jos\'eA. and Ruiz-Cort\'es, Antonio},
-	title={{Variability Testing in the Wild: The Drupal Case Study}},
-	issn={1619-1366},
-	journal=SoSyM,
-	doi={10.1007/s10270-015-0459-z},
-	url={http://dx.doi.org/10.1007/s10270-015-0459-z},
+	author = {S\'anchez, AnaB. and Segura, Sergio and Parejo, Jos\'eA. and Ruiz-Cort\'es, Antonio},
+	title = {{Variability Testing in the Wild: The Drupal Case Study}},
+	issn = {1619-1366},
+	journal = SoSyM,
+	doi = {10.1007/s10270-015-0459-z},
+	url = {http://dx.doi.org/10.1007/s10270-015-0459-z},
 	publisher = Springer,
 	address = BerlinHeidelberg,
-	pages={1-22},
-	year=2015
+	pages = {1-22},
+	year = 2015
 }
 
 @inproceedings{WKP:VaMoS15,
@@ -3985,7 +4096,7 @@
 @inproceedings{M:SE15,
 	author = {Mustafa Al-Hajjaji},
 	title = {{Scalable Sampling and Prioritization for Product-Line Testing}},
-	booktitle =  {Doktorandensymposium der Software Engineering},
+	booktitle = {Doktorandensymposium der Software Engineering},
 	pages = {295--298},
 	isbn = {978-3-88579-633-6},
 	issn = {1617-5468},
@@ -4047,6 +4158,40 @@
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% 2014 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
+@inproceedings{LMS:SEFM14,
+	title = {{A Thread-Safe Library for Binary Decision Diagrams}},
+	author = {Lovato, Alberto and Macedonio, Damiano and Spoto, Fausto},
+	booktitle = SEFM,
+	pages = {35--49},
+	publisher = Springer,
+	address = BerlinHeidelberg,
+	year = 2014
+}
+
+@article{BCHY:Heuristics14,
+	title = {{BDD-Based Heuristics for Binary Optimization}},
+	author = {Bergman, David and Cir{\'{e}}, Andr{\'{e}} A and van Hoeve, Willem-Jan and Yunes, Tallys},
+	journal = {J.\ of Heuristics},
+	volume = {20},
+	number = {2},
+	pages = {211--234},
+	publisher = Springer,	
+	address = BerlinHeidelberg,
+	month = APR,
+	year = 2014,
+}
+
+@article{BCHH:IJC14,
+	title = {{Optimization Bounds from Binary Decision Diagrams}},
+	author = {Bergman, David and Cire, Andre A and van Hoeve, Willem-Jan and Hooker, John N},
+	journal = IJC,
+	volume = {26},
+	number = {2},
+	pages = {253--268},
+	publisher = INFORMS,
+	year = 2014
+}
+
 @inproceedings{VSBK:SLE14,
 	title = {{Towards User-Friendly Projectional Editors}},
 	author = {Voelter, Markus and Siegmund, Janet and Berger, Thorsten and Kolb, Bernd},
@@ -4105,8 +4250,8 @@
 	doi = {10.14416/j.ijast.2014.05.001},
 	tt-tags = {SPL Testing},
 	tc-tags = {classified by Thomas,testing,sample-based analysis,specification independent,implementation independent,program,subsumed by none},
-	sampling-tags = {name=Cmyrev's greedy algorithm,compared to MoSo-PoLiTe,feature model,greedy,semi-automatic selection,feature-wise coverage,requirements coverage,sampling efficiency,testing efficiency,effectiveness,unavailable tool,evaluation,testing,SPLC18},
-	sampling2-tags = {name=Cmyrev's simulated annealing,compared to MoSo-PoLiTe,feature model,local search,semi-automatic selection,no coverage guarantee,sampling efficiency,testing efficiency,effectiveness,unavailable tool,evaluation,testing,SPLC18},
+	sampling-tags = {name = Cmyrev's greedy algorithm,compared to MoSo-PoLiTe,feature model,greedy,semi-automatic selection,feature-wise coverage,requirements coverage,sampling efficiency,testing efficiency,effectiveness,unavailable tool,evaluation,testing,SPLC18},
+	sampling2-tags = {name = Cmyrev's simulated annealing,compared to MoSo-PoLiTe,feature model,local search,semi-automatic selection,no coverage guarantee,sampling efficiency,testing efficiency,effectiveness,unavailable tool,evaluation,testing,SPLC18},
 	year = 2014
 }
 
@@ -4119,7 +4264,7 @@
 	doi = {10.1142/S0129626414410011},
 	tt-tags = {SPL Analysis},
 	tc-tags = {classified by Thomas,performance analysis,sample-based analysis,specification independent,implementation independent,program,subsumed by none},
-	sampling-tags = {name=function-learning heuristic,compared to feature-wise heuristic/pair-wise heuristic/higher-order heuristic/hot-spot heuristic,feature model,greedy,automatic selection,no coverage guarantee,testing efficiency,effectiveness,open-source tool,SPLConqueror,evaluation,non-functional properties,SPLC18},
+	sampling-tags = {name = function-learning heuristic,compared to feature-wise heuristic/pair-wise heuristic/higher-order heuristic/hot-spot heuristic,feature model,greedy,automatic selection,no coverage guarantee,testing efficiency,effectiveness,open-source tool,SPLConqueror,evaluation,non-functional properties,SPLC18},
 	year = 2014
 }
 
@@ -4163,8 +4308,8 @@
 	address = {Berkeley, CA, USA},
 	tt-tags = {SPL Analysis,Sampling},
 	tc-tags = {classified by Thomas,family-specific analysis,family-product-based analysis,sample-based analysis,build system,preprocessor,family-based implementation,domain-independent specification,source code,tool,evaluation,no proof,SAT},
-	sampling-tags = {name=vampyr,feature model,greedy,implementation artifacts,no coverage guarantee,open-source tool,evaluation,effectiveness,type checking,SPLC18},
-	sampling2-tags = {name=all-yes-config,feature model,manual selection,expert knowledge,no coverage guarantee,evaluation,effectiveness,type checking,SPLC18},
+	sampling-tags = {name = vampyr,feature model,greedy,implementation artifacts,no coverage guarantee,open-source tool,evaluation,effectiveness,type checking,SPLC18},
+	sampling2-tags = {name = all-yes-config,feature model,manual selection,expert knowledge,no coverage guarantee,evaluation,effectiveness,type checking,SPLC18},
 	year = 2014
 }
 
@@ -4425,7 +4570,7 @@
 	keywords = {model-based software engineering, software product lines, test case generation},
 	tt-tags = {SPL Testing},
 	tc-tags = {classified by Thomas,testing,sample-based analysis,family-based specification,implementation independent,design,program,no tool,no evaluation,no proof,subsumed by none},
-	sampling-tags = {name=incremental test-suite optimization,product set,test artifacts,greedy,requirements coverage,unavailable tool,no evaluation,no proof,testing},
+	sampling-tags = {name = incremental test-suite optimization,product set,test artifacts,greedy,requirements coverage,unavailable tool,no evaluation,no proof,testing},
 	year = 2014
 }
 
@@ -4441,20 +4586,20 @@
 }
 
 @incollection{HPL:SBSE14,
-	author={Henard, Christopher and Papadakis, Mike and Le Traon, Yves},
-	title={{Mutation-Based Generation of Software Product Line Test Configurations}},
-	isbn={978-3-319-09939-2},
-	booktitle={Search-Based Software Engineering},
-	volume={8636},
-	series={Lecture Notes in Computer Science},
-	editor={Le Goues, Claire and Yoo, Shin},
-	doi={10.1007/978-3-319-09940-8_7},
-	publisher={Springer International Publishing},
-	pages={92-106},	
+	author = {Henard, Christopher and Papadakis, Mike and Le Traon, Yves},
+	title = {{Mutation-Based Generation of Software Product Line Test Configurations}},
+	isbn = {978-3-319-09939-2},
+	booktitle = {Search-Based Software Engineering},
+	volume = {8636},
+	series = {Lecture Notes in Computer Science},
+	editor = {Le Goues, Claire and Yoo, Shin},
+	doi = {10.1007/978-3-319-09940-8_7},
+	publisher = {Springer International Publishing},
+	pages = {92-106},	
 	tt-tags = {SPL Testing},
 	tc-tags = {},
-	sampling-tags = {name=Henard's CNF mutation,compared to random sampling,feature model,local search,automatic selection,no coverage guarantee,sampling efficiency,testing efficiency,effectiveness,open-source tool,evaluation,testing,feature-model mutation,SPLC18},
-	year=2014
+	sampling-tags = {name = Henard's CNF mutation,compared to random sampling,feature model,local search,automatic selection,no coverage guarantee,sampling efficiency,testing efficiency,effectiveness,open-source tool,evaluation,testing,feature-model mutation,SPLC18},
+	year = 2014
 }
 
 @inproceedings{SO:SPLC14,
@@ -4847,7 +4992,7 @@
 	address = NY,
 	tt-tags = {Feature Interaction},
 	tc-tags = {analysis method undefined,sample-based analysis,implementation independent,no tool,evaluation,subsumed by AMS+:TOSEM18},
-	sampling-tags = {name=one-disabled,greedy,feature model,no coverage guarantee,evaluation,testing efficiency,effectiveness,evaluated with real faults,testing,subsumed by AMS+:TOSEM18,SPLC18},
+	sampling-tags = {name = one-disabled,greedy,feature model,no coverage guarantee,evaluation,testing efficiency,effectiveness,evaluated with real faults,testing,subsumed by AMS+:TOSEM18,SPLC18},
 	year = 2014
 } 
 
@@ -4862,7 +5007,7 @@
 	doi = {10.1109/TSE.2014.2327020},
 	tt-tags = {SPL Testing,Sampling},
 	tc-tags = {},
-	sampling-tags = {name=similarity heuristic,feature model,local search,no coverage guarantee,evaluation,sampling efficiency,testing efficiency,effectiveness,testing,a.k.a. PLEDGE,compared to IPOG/CASA/ICPL,SAT,SPLC18},
+	sampling-tags = {name = similarity heuristic,feature model,local search,no coverage guarantee,evaluation,sampling efficiency,testing efficiency,effectiveness,testing,a.k.a. PLEDGE,compared to IPOG/CASA/ICPL,SAT,SPLC18},
 	month = JUL, 
 	year = 2014
 }
@@ -4986,10 +5131,10 @@
 }
 
 @inproceedings{SR:SATTOSE14,
-	author={Schmorleiz, Thomas and L{\"a}mmel, Ralf},
-	title={{Similarity Management via History Annotation}},
-	booktitle=SATTOSE,
-	pages={45-48},
+	author = {Schmorleiz, Thomas and L{\"a}mmel, Ralf},
+	title = {{Similarity Management via History Annotation}},
+	booktitle = SATTOSE,
+	pages = {45-48},
 	year = 2014,
 	publisher = {Dipartimento di Informatica Universit{\`a} degli Studi dell'Aquila, L'Aquila, Italy},
 	month = jul,
@@ -5029,17 +5174,17 @@
 }
 
 @inproceedings{HSMI:ICST14,
-	author= {Baller, Hauke and Lity, Sascha and Lochau, Malte and Schaefer, Ina},
+	author = {Baller, Hauke and Lity, Sascha and Lochau, Malte and Schaefer, Ina},
  	title = {{Multi-Objective Test Suite Optimization for Incremental Product Family Testing}},
 	booktitle = ICST,
 	publisher = IEEE,
-	pages= {303-312},
+	pages = {303-312},
 	address = Washington,
 	location = {Cleveland, Ohio, USA},
 	doi = {10.1109/ICST.2014.43},
 	tt-tags = {SPL Testing},
 	tc-tags = {classified by Thomas,testing,test-case selection,sample-based analysis,optimized product-based analysis,implementation independent,family-based specification,requirements},
-	sampling-tags = {name=incremental heuristic,greedy,product set,test artifacts,requirements coverage,sampling efficiency,effectiveness,unavailable tool,evaluation,testing},
+	sampling-tags = {name = incremental heuristic,greedy,product set,test artifacts,requirements coverage,sampling efficiency,effectiveness,unavailable tool,evaluation,testing},
 	year = 2014
 }
 
@@ -5219,14 +5364,14 @@
 } 
 
 @article{WG+:JSS14,
-	author={White, Jules and Galindo, Jos{\'e} A and Saxena, Tripti and Dougherty, Brian and Benavides, David and Schmidt, Douglas C.},
-	title={{Evolving Feature Model Configurations in Software Product Lines}},
-	 journal=JSS,
-  	volume={87},
+	author = {White, Jules and Galindo, Jos{\'e} A and Saxena, Tripti and Dougherty, Brian and Benavides, David and Schmidt, Douglas C.},
+	title = {{Evolving Feature Model Configurations in Software Product Lines}},
+	 journal = JSS,
+  	volume = {87},
 	number = 0,
-	pages={119--136},
-  	publisher=Elsevier,
-  	year=2014
+	pages = {119--136},
+  	publisher = Elsevier,
+  	year = 2014
 
 }
 
@@ -5391,6 +5536,59 @@
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% 2013 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
+@inproceedings{DDH+:FSE13,
+	title = {{Feature Model Extraction From Large Collections of Informal Product Descriptions}},
+	author = {Davril, Jean-Marc and Delfosse, Edouard and Hariri, Negar and Acher, Mathieu and Cleland-Huang, Jane and Heymans, Patrick},
+	booktitle = FSE,
+	pages = {290--300},
+	publisher = ACM,
+	address = NY,
+	year = 2013
+}
+
+@article{DLP:ENTCS13,
+	title = {{Multi-Core BDD Operations for Symbolic Reachability}},
+	author = {van Dijk, Tom and Laarman, Alfons and van De Pol, Jaco},
+	journal = {Electron. Notes Theor. Comput. Sci.},
+	volume = {296},
+	pages = {127--143},
+	publisher = Elsevier,
+	address = Amsterdam,
+	year = 2013
+}
+
+@book{ST13,
+	title = {{The Satisfiability Problem: Algorithms and Analyses}},
+	author = {Sch{\"o}ning, Uwe and Tor{\'a}n, Jacobo},
+	volume = {3},
+	publisher = {Lehmanns Media},
+	address = {Cologne, Germany},
+	year = 2013,
+}
+
+@article{CH:JOR13,
+	title = {{Multivalued Decision Diagrams for Sequencing Problems}},
+	author = {Cir{\'e}, Andr{\'e} A and van Hoeve, Willem-Jan},
+	journal = {J.\ on Operations Research},
+	volume = {61},
+	number = {6},
+	pages = {1411--1428},
+	publisher = INFORMS,
+	address = Catonsville,
+	year = 2013
+}
+
+@inproceedings{KH:CPAIOR13,
+	title = {{An MDD Approach to Multidimensional Bin Packing}},
+	author = {Kell, Brian and Van Hoeve, Willem-Jan},
+	booktitle = CPAIOR,
+	pages = {128--143},
+	publisher = Springer,
+	address = BerlinHeidelberg,
+	year = 2013
+}
+
+
 @mastersthesis{L13,
 	author = {Lei Luo},
 	title = {{Synchronisierung von Software-Varianten mit VariantSync}},
@@ -5398,7 +5596,7 @@
 	address = {Germany},
 	tt-tags = {Clone-and-Own,SPL Migration,VariantSync},
 	month = JAN,
-	year = 2016,
+	year = 2013,
 	typo3Tags = {VariantSyncMT},
 	note = {In German}
 }
@@ -5587,7 +5785,7 @@
 	keywords = {feature modelling, software product lines, variability management},
 	tt-tags = {},
 	tc-tags = {},
-	sampling-tags = {name=Marijan's configuration generation,usage of PACOGEN,feature model,local search,pair-wise coverage,sampling efficiency,testing efficiency,effectiveness,evaluation,testing,SPLC18},
+	sampling-tags = {name = Marijan's configuration generation,usage of PACOGEN,feature model,local search,pair-wise coverage,sampling efficiency,testing efficiency,effectiveness,evaluation,testing,SPLC18},
 	year = 2013
 } 
 
@@ -5621,7 +5819,7 @@
 	publisher = ButterworthHeinemann,
 	address = Newton,
 	keywords = {Measurement, Non-functional properties, Prediction, SPL Conqueror, Software product lines},
-	sampling-tags = {name=interaction-wise heuristic,compared to feature-wise heuristic/pair-wise heuristic,feature model,greedy,automatic selection,no coverage guarantee,testing efficiency,effectiveness,open-source tool,evaluation,non-functional properties,SPLConqueror,SAT,SPLC18},
+	sampling-tags = {name = interaction-wise heuristic,compared to feature-wise heuristic/pair-wise heuristic,feature model,greedy,automatic selection,no coverage guarantee,testing efficiency,effectiveness,open-source tool,evaluation,non-functional properties,SPLConqueror,SAT,SPLC18},
 	month = MAR,
 	year = 2013
 }
@@ -5638,7 +5836,7 @@
 	publisher = IEEE,
 	address = Piscataway,
 	tc-tags = {classified by Thomas,performance analysis,sample-based analysis,specification independent,implementation independent,program,subsumed by GYS+:EMSE18},
-	sampling-tags = {name=random sampling,greedy,feature model,no coverage guarantee,testing efficiency,open-source tool,DECART,evaluation,non-functional properties,subsumed by GYS+:EMSE18,SPLC18},
+	sampling-tags = {name = random sampling,greedy,feature model,no coverage guarantee,testing efficiency,open-source tool,DECART,evaluation,non-functional properties,subsumed by GYS+:EMSE18,SPLC18},
 	year = 2013
 } 
 
@@ -5657,7 +5855,7 @@
 	keywords = {combinatorial testing, evaluation, feature model-based testing, pairwise testing, product lines},
 	tt-tags = {},
 	tc-tags = {},
-	sampling-tags = {name=coverage array reduction,evaluation with ICPL,feature model,greedy,automatic selection,t-wise coverage,sampling efficiency,testing efficiency,unavailable tool,evaluation,testing,SPLC18},
+	sampling-tags = {name = coverage array reduction,evaluation with ICPL,feature model,greedy,automatic selection,t-wise coverage,sampling efficiency,testing efficiency,unavailable tool,evaluation,testing,SPLC18},
 	year = 2013
 } 
 
@@ -6020,7 +6218,7 @@
 	doi = {10.1145/2491627.2491635},
 	tt-tags = {SPL Testing},
 	tc-tags = {},
-	sampling-tags = {name=moga,feature model,expert knowledge,population-based search,semi-automatic selection,no coverage guarantee,sampling efficiency,testing efficiency,effectiveness,open-source tool,evaluation,testing,compared to random sampling,SPLC18},
+	sampling-tags = {name = moga,feature model,expert knowledge,population-based search,semi-automatic selection,no coverage guarantee,sampling efficiency,testing efficiency,effectiveness,open-source tool,evaluation,testing,compared to random sampling,SPLC18},
 	year = 2013
 }
 
@@ -6038,7 +6236,7 @@
 	keywords = {feature models, software product lines, testing},
 	tt-tags = {SPL Testing},
 	tc-tags = {},
-	sampling-tags = {name=feature-model filtering,greedy,feature model,expert knowledge,t-wise coverage,sampling efficiency,testing efficiency,no tool,evaluation,testing,compared to ICPL,SPLC18},
+	sampling-tags = {name = feature-model filtering,greedy,feature model,expert knowledge,t-wise coverage,sampling efficiency,testing efficiency,no tool,evaluation,testing,compared to ICPL,SPLC18},
 	year = 2013
 } 
 
@@ -6098,8 +6296,8 @@
 	address = NY,
 	tt-tags = {SPL Type Checking,SPL Static Analysis},
 	tc-tags = {classified by Thomas+Sven,type checking, static analysis,family-based analysis, sample-based analysis,domain-independent specification, family-wide specification,annotation-based implementation,source code / program,subsumed by none,CSUR14,PhD15},
-	sampling-tags = {name=single-conf heuristic,manual selection,feature model,expert knowledge,no coverage guarantee,sampling efficiency,testing efficiency,open-source tool,evaluation,no prioritization,data-flow analysis,type checking,compared to configuration coverage/ICPL/family-based analysis,SPLC18},
-	sampling2-tags = {name=random sampling,greedy,feature model,no coverage guarantee,sampling efficiency,testing efficiency,open-source tool,evaluation,no prioritization,data-flow analysis,type checking,compared to configuration coverage/ICPL/family-based analysis,SPLC18},
+	sampling-tags = {name = single-conf heuristic,manual selection,feature model,expert knowledge,no coverage guarantee,sampling efficiency,testing efficiency,open-source tool,evaluation,no prioritization,data-flow analysis,type checking,compared to configuration coverage/ICPL/family-based analysis,SPLC18},
+	sampling2-tags = {name = random sampling,greedy,feature model,no coverage guarantee,sampling efficiency,testing efficiency,open-source tool,evaluation,no prioritization,data-flow analysis,type checking,compared to configuration coverage/ICPL/family-based analysis,SPLC18},
 	month = AUG,
 	year = 2013
 }
@@ -6323,7 +6521,7 @@ Ricardo and Zimmerman, Daniel M. and Corn\'elio, M\'arcio and Th\"um, Thomas},
 	title = {{AspectJML: Modular Specification and Runtime Checking for Crosscutting Contracts}},
 	institution = {University of Central Florida, Computer Science},
 	address = {Orlando, FL, USA},
-	number= {CS-TR-13-07},
+	number = {CS-TR-13-07},
 	tt-tags = {Aspect Orientation,Design by Contract},
 	month = SEP,
 	year = 2013
@@ -6516,7 +6714,7 @@ Ricardo and Zimmerman, Daniel M. and Corn\'elio, M\'arcio and Th\"um, Thomas},
 	title = {{Model Checking Adaptive Software with Featured Transition Systems}},
 	booktitle = ASAS,
 	pages = {1-29},
-	isbn={978-3-642-36248-4},
+	isbn = {978-3-642-36248-4},
 	doi = {10.1007/978-3-642-36249-1_1},
 	publisher = Springer,
 	address = BerlinHeidelberg,
@@ -6728,7 +6926,7 @@ Ricardo and Zimmerman, Daniel M. and Corn\'elio, M\'arcio and Th\"um, Thomas},
 	title = {{ReFlO: An Interactive Tool for Pipe-And-Filter Domain Specification and Program Generation}},
 	institution = {The University of Texas at Austin, Department of Computer Sciences},
 	address = {Austin, TX, USA},
-	number= {CS-TR-13-02},
+	number = {CS-TR-13-02},
 	tt-tags = {Behavioral Subtyping},
 	month = FEB,
 	year = 2013
@@ -6796,6 +6994,38 @@ Ricardo and Zimmerman, Daniel M. and Corn\'elio, M\'arcio and Th\"um, Thomas},
 }
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% 2012 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+@inproceedings{LCF+:TASE12,
+	title = {{A Succinct and Efficient Implementation of a 2\^{} 32 BDD Package}},
+	author = {Lv, Guanfeng and Chen, Yao and Feng, Yachao and Chen, Qingliang and Su, Kaile},
+	booktitle = {Proc.\ Int'l Symposium on Theoretical Aspects of Software Engineering (TASE)},
+	pages = {241--244},
+	publisher = IEEE,
+	address = Washington,
+	year = 2012,
+}
+
+@article{M:JSW12,
+	title = {Biddy - a Multi-platform Academic {BDD} Package},
+	author = {Meolic, Robert},
+	journal = {J.\ of Software (JSW)},
+	volume = {7},
+	number = {6},
+	pages = {1358--1366},
+	publisher = {{International Academy Publishing (IAP)}},
+	address = {San Bernardino, CA, USA},
+	year = 2012
+}
+
+@inproceedings{BCHH:CPAIOR12,
+	title = {{Variable Ordering for the Application of Bdds to the Maximum Independent Set Problem}},
+	author = {Bergman, David and Cir{\'e}, Andr{\'e} A and van Hoeve, Willem-Jan and Hooker, John N},
+	booktitle = CPAIOR,
+	pages = {34--49},
+	publisher = Springer,
+	address = BerlinHeidelberg,
+	year = 2012
+}
 
 @article{RPK:SCP12,
 	title = {{Automatic Library Migration for the Generation of Hardware-In-The-Loop Models}},
@@ -6948,7 +7178,7 @@ Ricardo and Zimmerman, Daniel M. and Corn\'elio, M\'arcio and Th\"um, Thomas},
 	acmid = {2337243},
 	publisher = IEEE,
 	address = Piscataway,
-	sampling-tags = {name=higher-order heuristic/hot-spot heuristic,compared to feature-wise/pair-wise/all valid configurations,feature model,greedy,automatic selection,no coverage guarantee,testing efficiency,effectiveness,evaluation,open-source tool,non-functional properties,SPLConqueror,SAT,SPLC18},
+	sampling-tags = {name = higher-order heuristic/hot-spot heuristic,compared to feature-wise/pair-wise/all valid configurations,feature model,greedy,automatic selection,no coverage guarantee,testing efficiency,effectiveness,evaluation,open-source tool,non-functional properties,SPLConqueror,SAT,SPLC18},
 	year = 2012
 }
 
@@ -6965,8 +7195,8 @@ Ricardo and Zimmerman, Daniel M. and Corn\'elio, M\'arcio and Th\"um, Thomas},
 	publisher = Kluwer,
 	address = Hingham,
 	keywords = {Feature-oriented software development, Measurement and optimization, Non-functional properties, SPL Conqueror, Software product lines},
-	sampling-tags = {name=feature-wise heuristic,feature model,greedy,automatic selection,feature-wise coverage,testing efficiency,effectiveness,evaluation,open-source tool,non-functional properties,SPLConqueror,SAT,SPLC18},
-	sampling2-tags = {name=pair-wise heuristic,feature model,greedy,automatic selection,pair-wise coverage,testing efficiency,effectiveness,evaluation,open-source tool,non-functional properties,SPLConqueror,SAT,SPLC18},
+	sampling-tags = {name = feature-wise heuristic,feature model,greedy,automatic selection,feature-wise coverage,testing efficiency,effectiveness,evaluation,open-source tool,non-functional properties,SPLConqueror,SAT,SPLC18},
+	sampling2-tags = {name = pair-wise heuristic,feature model,greedy,automatic selection,pair-wise coverage,testing efficiency,effectiveness,evaluation,open-source tool,non-functional properties,SPLConqueror,SAT,SPLC18},
 	month = SEP,
 	year = 2012
 }
@@ -7035,24 +7265,24 @@ Ricardo and Zimmerman, Daniel M. and Corn\'elio, M\'arcio and Th\"um, Thomas},
 }
 
 @INPROCEEDINGS{DGK+:ICST12, 
-	author={Devine, Thomas R. and Goseva-Popstajanova, Katerina and Krishnan, Sandeep and Lutz, Robyn R. and Li, J. Jenny}, 
-	title={{An Empirical Study of Pre-Release Software Faults in an Industrial Product Line}}, 
-	booktitle=ICST, 
-	month= APR, 
-	pages={181-190}, 
-	doi={10.1109/ICST.2012.98},
-	year=2012
+	author = {Devine, Thomas R. and Goseva-Popstajanova, Katerina and Krishnan, Sandeep and Lutz, Robyn R. and Li, J. Jenny}, 
+	title = {{An Empirical Study of Pre-Release Software Faults in an Industrial Product Line}}, 
+	booktitle = ICST, 
+	month = APR, 
+	pages = {181-190}, 
+	doi = {10.1109/ICST.2012.98},
+	year = 2012
 }
 
 @article{YH:STVR12,
-	 author={Yoo, Shin and Harman, Mark},
-  	title={{Regression Testing Minimization, Selection and Prioritization: A Survey}},
-	journal=STVR,
- 	volume={22},
-  	number={2},
-  	pages={67--120},
-  	publisher={Wiley Online Library},
-	year=2012
+	 author = {Yoo, Shin and Harman, Mark},
+  	title = {{Regression Testing Minimization, Selection and Prioritization: A Survey}},
+	journal = STVR,
+ 	volume = {22},
+  	number = {2},
+  	pages = {67--120},
+  	publisher = {Wiley Online Library},
+	year = 2012
 }
 @inproceedings{HZDK:ICSM12,
 	author = {Hassan, Ahmed E. and Zou, Ying and Dhaliwal, Tejinder and Khomh, Foutse},
@@ -7070,7 +7300,7 @@ Ricardo and Zimmerman, Daniel M. and Corn\'elio, M\'arcio and Th\"um, Thomas},
 @inproceedings{BEG:CASCON12,
 	 author = {Bagheri, Ebrahim and Ensan, Faezeh and Gasevic, Dragan},
  	title = {{Grammar-based Test Generation for Software Product Line Feature Models}},
- 	booktitle =CASCON,
+ 	booktitle = CASCON,
  	location = {Toronto, Ontario, Canada},
  	pages = {87--101},
  	numpages = {15},
@@ -7081,21 +7311,19 @@ Ricardo and Zimmerman, Daniel M. and Corn\'elio, M\'arcio and Th\"um, Thomas},
 	year = 2012
 }
 
-
-
 @inproceedings{AHC+:CAiSE12,
-  author = {Mathieu Acher and Patrick Heymans and Philippe Collet and Cl{\'{e}}ment Quinton and Philippe Lahire and Philippe Merle},
-  title = {{Feature Model Differences}},
-  booktitle = CAiSE,
+	author = {Mathieu Acher and Patrick Heymans and Philippe Collet and Cl{\'{e}}ment Quinton and Philippe Lahire and Philippe Merle},
+	title = {{Feature Model Differences}},
+	booktitle = CAiSE,
 	location = {Gdansk, Poland},
-  pages = {629--645},
-  doi = {10.1007/978-3-642-31095-9_41},
-  isbn = {978-3-642-31094-2},
-  publisher = Springer,
+	pages = {629--645},
+	doi = {10.1007/978-3-642-31095-9_41},
+	isbn = {978-3-642-31094-2},
+	publisher = Springer,
 	address = BerlinHeidelberg,
 	tt-tags = {Feature Model Diffing,Complex Constraints},
 	month = JUN,
-  year = 2012
+	year = 2012
 }
 
 @inproceedings{SGB+:VaMoS12,
@@ -7167,7 +7395,7 @@ Ricardo and Zimmerman, Daniel M. and Corn\'elio, M\'arcio and Th\"um, Thomas},
 	pages = {613--628},
 	tt-tags = {},
 	tc-tags = {},
-	sampling-tags = {name=gasplt,usage of FAMA,feature model,local search,automatic selection,no coverage guarantee,testing efficiency,effectiveness,open-source tool,evaluation,testing,SPLC18},
+	sampling-tags = {name = gasplt,usage of FAMA,feature model,local search,automatic selection,no coverage guarantee,testing efficiency,effectiveness,open-source tool,evaluation,testing,SPLC18},
 	year = 2012
 }
 
@@ -7297,7 +7525,7 @@ Ricardo and Zimmerman, Daniel M. and Corn\'elio, M\'arcio and Th\"um, Thomas},
 	address = NY,
 	tt-tags = {Sampling},
 	tc-tags = {feature-model analysis,sample-based analysis,implementation independent,specification independent,tool,evaluation},
-	sampling-tags = {name=ICPL,feature model,greedy,t-wise coverage,evaluation,sampling efficiency,testing efficiency,open-source tool,testing,compared to CASA/IPOG/MoSo-PoLiTe,a.k.a. SPLCAT,SPLC18},
+	sampling-tags = {name = ICPL,feature model,greedy,t-wise coverage,evaluation,sampling efficiency,testing efficiency,open-source tool,testing,compared to CASA/IPOG/MoSo-PoLiTe,a.k.a. SPLCAT,SPLC18},
   	year = 2012
 }
 
@@ -7321,8 +7549,8 @@ Ricardo and Zimmerman, Daniel M. and Corn\'elio, M\'arcio and Th\"um, Thomas},
 	address = BerlinHeidelberg,
 	tt-tags = {},
 	tc-tags = {},
-	sampling-tags = {name=weight coverage,compared to ICPL,usage of ICPL,feature model,expert knowledge,greedy,semi-automatic selection,no coverage guarantee,testing efficiency,effectiveness,open-source tool,evaluation,testing,SPLC18},
- 	year=2012
+	sampling-tags = {name = weight coverage,compared to ICPL,usage of ICPL,feature model,expert knowledge,greedy,semi-automatic selection,no coverage guarantee,testing efficiency,effectiveness,open-source tool,evaluation,testing,SPLC18},
+ 	year = 2012
 }
 
 @article{POS+:SQJ12,
@@ -7342,13 +7570,13 @@ Ricardo and Zimmerman, Daniel M. and Corn\'elio, M\'arcio and Th\"um, Thomas},
 }
 
 @phdthesis{O:PhD12,
- 	author={Oster, Sebastian},
-  	title={{Feature Model-Based Software Product Line Testing}},
+ 	author = {Oster, Sebastian},
+  	title = {{Feature Model-Based Software Product Line Testing}},
  	school = {TU Darmstadt},
-  	publisher={TU Darmstadt},
+  	publisher = {TU Darmstadt},
 	month = JAN,
 	address = {Darmstadt},
-  	year=2012
+  	year = 2012
 }
 
 @book{WRH+12,
@@ -7847,7 +8075,7 @@ Ricardo and Zimmerman, Daniel M. and Corn\'elio, M\'arcio and Th\"um, Thomas},
 	title = {{Large-Scale Variability-Aware Type Checking and Dataflow Analysis}},
 	institution = {University of Passau},
 	address = {Germany},
-	number= {MIP-1212},
+	number = {MIP-1212},
 	tt-tags = {SPL Type Checking,SPL Static Analysis},
 	tc-tags = {classified by Thomas+Sven,type checking, static analysis,family-based analysis, sample-based analysis,domain-independent specification, family-wide specification,annotation-based implementation,source code / program,subsumed by LKA+:ESECFSE13,CSUR14,PhD15},
 	month = NOV,
@@ -7876,7 +8104,7 @@ Ricardo and Zimmerman, Daniel M. and Corn\'elio, M\'arcio and Th\"um, Thomas},
 	title = {{Transparent and Efficient Reuse of IFDS-Based Static Program Analyses for Software Product Lines}},
 	institution = {EC SPRIDE, Technische Universit\"at Darmstadt},
 	address = {Germany},
-	number= {TUD-CS-2012-0239},
+	number = {TUD-CS-2012-0239},
 	tt-tags = {SPL Static Analysis},
 	tc-tags = {classified by Thomas+(Eric Bodden)+Christian,static analysis,family-based analysis,family-wide specification,annotation-based implementation,source code / program,subsumed by BMB+:PLDI13,CSUR14,PhD15},
 	month = NOV,
@@ -8052,7 +8280,7 @@ Ricardo and Zimmerman, Daniel M. and Corn\'elio, M\'arcio and Th\"um, Thomas},
 	location = {Tallinn, Estonia},
 	tt-tags = {SPL Testing,SPL Static Analysis,Feature Interaction,Abstract Features,Pairwise Testing},
 	tc-tags = {classified by Thomas+Christian,static analysis, testing,family-product-based analysis,domain-independent specification,annotation-based implementation,source code / program,subsumed by none,CSUR14,PhD15},
-	sampling-tags = {name=Shi's dataflow analysis,feature model,implementation artifacts,greedy,code coverage,t-wise coverage,sampling efficiency,unavailable tool,evaluation,testing,SPLC18},
+	sampling-tags = {name = Shi's dataflow analysis,feature model,implementation artifacts,greedy,code coverage,t-wise coverage,sampling efficiency,unavailable tool,evaluation,testing,SPLC18},
 	month = MAR,
 	year = 2012
 }
@@ -8121,7 +8349,7 @@ Ricardo and Zimmerman, Daniel M. and Corn\'elio, M\'arcio and Th\"um, Thomas},
 @inproceedings{DDJ+:FMSPLE12,
 	author = {Damiani, Ferruccio and Owe, Olaf and Dovland, Johan and Schaefer, Ina and Johnsen, Einar Broch and Yu, Ingrid Chieh},
 	title = {{A Transformational Proof System for Delta-Oriented Programming}},
-	booktitle =	FMSPLE,
+	booktitle = FMSPLE,
 	publisher = ACM,
 	address = NY,
 	isbn = {978-1-4503-1095-6},
@@ -8250,8 +8478,8 @@ Ricardo and Zimmerman, Daniel M. and Corn\'elio, M\'arcio and Th\"um, Thomas},
 	address = NY,
 	tt-tags = {Preprocessors,SPL Configuration Analysis},
 	tc-tags = {classified by Sven+Thomas,family-specific analysis,sample-based analysis,domain-independent specification,annotation-based implementation,source code / program,subsumed by none,CSUR14,PhD15},
-	sampling-tags = {name=all-yes-config,feature model,manual selection,expert knowledge,no coverage guarantee,sampling efficiency,effectiveness,open-source tool,evaluation,no prioritization,type checking,SPLC18},
-	sampling2-tags = {name=configuration coverage,feature model,greedy,implementation artifacts,code coverage,sampling efficiency,effectiveness,open-source tool,evaluation,no prioritization,Undertaker,type checking,SPLC18},
+	sampling-tags = {name = all-yes-config,feature model,manual selection,expert knowledge,no coverage guarantee,sampling efficiency,effectiveness,open-source tool,evaluation,no prioritization,type checking,SPLC18},
+	sampling2-tags = {name = configuration coverage,feature model,greedy,implementation artifacts,code coverage,sampling efficiency,effectiveness,open-source tool,evaluation,no prioritization,Undertaker,type checking,SPLC18},
 	month = JAN,
 	year = 2012
 }
@@ -8442,7 +8670,7 @@ Ricardo and Zimmerman, Daniel M. and Corn\'elio, M\'arcio and Th\"um, Thomas},
 @inproceedings{KLG:MSR11,
 	author = {Krishnan, Sandeep and Lutz, Robyn R. and Go\v{s}eva-Popstojanova, Katerina},
 	title = {{Empirical Evaluation of Reliability Improvement in an Evolving Software Product Line}},
-	booktitle =MSR,
+	booktitle = MSR,
 	isbn = {978-1-4503-0574-7},
 	location = {Waikiki, Honolulu, HI, USA},
 	pages = {103--112},
@@ -8456,25 +8684,25 @@ Ricardo and Zimmerman, Daniel M. and Corn\'elio, M\'arcio and Th\"um, Thomas},
 } 
 
 @article{CMN:STVR11,
- 	 author={Cartaxo, Emanuela G and Machado, Patr{\'\i}cia DL and Neto, Francisco G Oliveira},
- 	 title={{On the Use of a Similarity Function for Test Case Selection in the Context of Model-Based Testing}},
- 	 journal=STVR,
-  	volume={21},
-  	number={2},
-  	pages={75--100},
- 	 publisher={Wiley Online Library},
- 	 year=2011
+ 	 author = {Cartaxo, Emanuela G and Machado, Patr{\'\i}cia DL and Neto, Francisco G Oliveira},
+ 	 title = {{On the Use of a Similarity Function for Test Case Selection in the Context of Model-Based Testing}},
+ 	 journal = STVR,
+  	volume = {21},
+  	number = {2},
+  	pages = {75--100},
+ 	 publisher = {Wiley Online Library},
+ 	 year = 2011
 }
 
 @INPROCEEDINGS{GC:ISSRE11, 
-	author={Garvin, B.J. and Cohen, M.B.}, 
-	title={{Feature Interaction Faults Revisited: An Exploratory Study}}, 
-	booktitle=ISSRE, 
-	month={Nov}, 
-	pages={90-99}, 
-	doi={10.1109/ISSRE.2011.25}, 
-	ISSN={1071-9458},
-	year=2011
+	author = {Garvin, B.J. and Cohen, M.B.}, 
+	title = {{Feature Interaction Faults Revisited: An Exploratory Study}}, 
+	booktitle = ISSRE, 
+	month = {Nov}, 
+	pages = {90-99}, 
+	doi = {10.1109/ISSRE.2011.25}, 
+	ISSN = {1071-9458},
+	year = 2011
 }
 
 @inproceedings{AB:ICSE11,
@@ -8486,30 +8714,30 @@ Ricardo and Zimmerman, Daniel M. and Corn\'elio, M\'arcio and Th\"um, Thomas},
 	 pages = {1--10},
 	 numpages = {10},
 	  publisher = ACM,
-	 address =NY,
+	 address = NY,
 	 year = 2011
 
 } 
 
 @INPROCEEDINGS{HBG:ISSRE11, 
-	author={Hervieu, A and Baudry, B. and Gotlieb, A}, 
-	title={{PACOGEN: Automatic Generation of Pairwise Test Configurations from Feature Models}}, 
-	booktitle=ISSRE,
-	month={Nov}, 
-	pages={120-129}, 
+	author = {Hervieu, A and Baudry, B. and Gotlieb, A}, 
+	title = {{PACOGEN: Automatic Generation of Pairwise Test Configurations from Feature Models}}, 
+	booktitle = ISSRE,
+	month = {Nov}, 
+	pages = {120-129}, 
 	publisher = IEEE,
-	year=2011
+	year = 2011
 }
 
 @article{BG:SQJ11,
-	author={Bagheri, Ebrahim and Gasevic, Dragan},
-	title={{Assessing the Maintainability of Software Product Line Feature Models Using Structural Metrics}},
-	journal=SQJ,
-	volume={19},
-	number={3},
-	 pages={579-612},
-	publisher=Springer,
-	year=2011
+	author = {Bagheri, Ebrahim and Gasevic, Dragan},
+	title = {{Assessing the Maintainability of Software Product Line Feature Models Using Structural Metrics}},
+	journal = SQJ,
+	volume = {19},
+	number = {3},
+	 pages = {579-612},
+	publisher = Springer,
+	year = 2011
 }
 
 @inproceedings{ALB+:ESECFSE11,
@@ -8636,7 +8864,7 @@ Ricardo and Zimmerman, Daniel M. and Corn\'elio, M\'arcio and Th\"um, Thomas},
 	doi = {10.1109/ITNG.2011.58},
 	tt-tags = {},
 	tc-tags = {},
-	sampling-tags = {name=Ensan's algorithm,feature model,expert knowledge,greedy,semi-automatic selection,no coverage guarantee,testing efficiency,evaluation,testing,SPLC18},
+	sampling-tags = {name = Ensan's algorithm,feature model,expert knowledge,greedy,semi-automatic selection,no coverage guarantee,testing efficiency,evaluation,testing,SPLC18},
 	year = 2011
 }
 
@@ -8652,7 +8880,7 @@ Ricardo and Zimmerman, Daniel M. and Corn\'elio, M\'arcio and Th\"um, Thomas},
 	address = BerlinHeidelberg,
 	tt-tags = {},
 	tc-tags = {},
-	sampling-tags = {name=Chvatal's algorithm,usage of FeatureIDE/SPLAR/Sat4J,feature model,greedy,automatic selection,t-wise coverage,sampling efficiency,sampling efficiency,open-source tool,evaluation,testing,SPLC18},
+	sampling-tags = {name = Chvatal's algorithm,usage of FeatureIDE/SPLAR/Sat4J,feature model,greedy,automatic selection,t-wise coverage,sampling efficiency,sampling efficiency,open-source tool,evaluation,testing,SPLC18},
 	year = 2011
 }
 
@@ -8668,7 +8896,7 @@ Ricardo and Zimmerman, Daniel M. and Corn\'elio, M\'arcio and Th\"um, Thomas},
 	address = BerlinHeidelberg,
 	tt-tags = {},
 	tc-tags = {},
-	sampling-tags = {name=CASA,feature model,local search,automatic selection,t-wise coverage,sampling efficiency,testing efficiency,open-source tool,evaluation,testing,compared to CDS:TSE08,SPLC18},
+	sampling-tags = {name = CASA,feature model,local search,automatic selection,t-wise coverage,sampling efficiency,testing efficiency,open-source tool,evaluation,testing,compared to CDS:TSE08,SPLC18},
 	year = 2011
 }
 
@@ -9141,7 +9369,7 @@ Ricardo and Zimmerman, Daniel M. and Corn\'elio, M\'arcio and Th\"um, Thomas},
 	location = {Porto de Galinhas, Brazil},
 	tt-tags = {Feature Orientation,SPL Static Analysis,SPL Testing},
 	tc-tags = {classified by Martin+Thomas,static analysis, testing,family-product-based analysis,family-wide specification,composition-based implementation, annotation-based implementation,source code / program,subsumed by none,CSUR14,PhD15},
-	sampling-tags = {name=Kim's combinatorial reduction,usage of Sat4J,feature model,implementation artifacts,test artifacts,greedy,automatic selection,code coverage,sampling efficiency,testing efficiency,unavailable tool,evaluation,testing,SPLC18},
+	sampling-tags = {name = Kim's combinatorial reduction,usage of Sat4J,feature model,implementation artifacts,test artifacts,greedy,automatic selection,code coverage,sampling efficiency,testing efficiency,unavailable tool,evaluation,testing,SPLC18},
 	year = 2011
 }
 
@@ -9308,9 +9536,9 @@ Ricardo and Zimmerman, Daniel M. and Corn\'elio, M\'arcio and Th\"um, Thomas},
   journal = Computer,
   volume = {44},
   number = {2},
-  pages =	{82--85},
+  pages = {82--85},
 	tt-tags = {SPL Specification,SPL Model Checking,SPL Theorem Proving},
-  month =	FEB,
+  month = FEB,
   year = 2011,
 }
 
@@ -9355,7 +9583,7 @@ Ricardo and Zimmerman, Daniel M. and Corn\'elio, M\'arcio and Th\"um, Thomas},
 	pages = {160-169},
 	location = {Munich, Germany},
 	tt-tags = {},
-	sampling-tags = {name=interaction-wise heuristic,compared to feature-wise heuristic/pair-wise heuristic,feature model,greedy,automatic selection,no coverage guarantee,testing efficiency,effectiveness,open-source tool,evaluation,non-functional properties,SPLConqueror,SAT,SPLC18,subsumed by SRK+:IST13},
+	sampling-tags = {name = interaction-wise heuristic,compared to feature-wise heuristic/pair-wise heuristic,feature model,greedy,automatic selection,no coverage guarantee,testing efficiency,effectiveness,open-source tool,evaluation,non-functional properties,SPLConqueror,SAT,SPLC18,subsumed by SRK+:IST13},
 	month = AUG,
 	year = 2011
 }
@@ -9383,7 +9611,7 @@ Ricardo and Zimmerman, Daniel M. and Corn\'elio, M\'arcio and Th\"um, Thomas},
 	publisher = IEEE,
   address = Washington,
 	pages = {180--189},
-	doi={10.1109/ICST.2011.20},
+	doi = {10.1109/ICST.2011.20},
 	location = {Berlin, Germany},
 	tt-tags = {},
 	tc-tags = {classified by Thomas,runtime analysis,unoptimized product-based analysis,domain-independent specification,annotation-based implementation,source code / program,subsumed by none},
@@ -9754,7 +9982,7 @@ Ricardo and Zimmerman, Daniel M. and Corn\'elio, M\'arcio and Th\"um, Thomas},
 	address = NY,
 	tt-tags = {Feature Orientation,SPL Static Analysis,SPL Testing},
 	tc-tags = {classified by Thomas,static analysis, testing,family-product-based analysis,family-wide specification,composition-based implementation, annotation-based implementation,source code / program,subsumed by KBK:AOSD11,CSUR14,PhD15},
-	sampling-tags = {name=Kim's combinatorial reduction,usage of Sat4J,feature model,implementation artifacts,test artifacts,greedy,automatic selection,code coverage,sampling efficiency,testing efficiency,unavailable tool,evaluation,testing,subsumed by KBK:AOSD11,SPLC18},
+	sampling-tags = {name = Kim's combinatorial reduction,usage of Sat4J,feature model,implementation artifacts,test artifacts,greedy,automatic selection,code coverage,sampling efficiency,testing efficiency,unavailable tool,evaluation,testing,subsumed by KBK:AOSD11,SPLC18},
 	year = 2010
 } 
 
@@ -9833,7 +10061,7 @@ Ricardo and Zimmerman, Daniel M. and Corn\'elio, M\'arcio and Th\"um, Thomas},
 @inproceedings{MCP+:FMSPLE10,
 	author = {Muschevici, Radu and Clarke, Dave and Proenca, Jos\'e},
 	title = {{Feature Petri Nets}},
-	booktitle =	FMSPLE,
+	booktitle = FMSPLE,
 	publisher = {Lancaster University},
 	address = {Lancaster, UK},
 	isbn = {978-1-86220-274-0},
@@ -9857,13 +10085,13 @@ Ricardo and Zimmerman, Daniel M. and Corn\'elio, M\'arcio and Th\"um, Thomas},
 	pages = {285--299},
 	tt-tags = {Feature Orientation,Aspect Orientation,SPL Static Analysis,SPL Testing},
 	tc-tags = {classified by Martin+Thomas+(Eric Bodden),static analysis, testing,family-product-based analysis,family-wide specification,composition-based implementation,source code / program,subsumed by none,CSUR14,PhD15},
-	sampling-tags = {name=Kim's monitoring technique,feature model,implementation artifacts,test artifacts,greedy,automatic selection,code coverage,sampling efficiency,testing efficiency,unavailable tool,evaluation,testing,SPLC18},
+	sampling-tags = {name = Kim's monitoring technique,feature model,implementation artifacts,test artifacts,greedy,automatic selection,code coverage,sampling efficiency,testing efficiency,unavailable tool,evaluation,testing,SPLC18},
 	month = NOV,
 	year = 2010
 }
 
 @article{ALMK10,
-	author={Apel, Sven and Lengauer, Christian and M{\"o}ller, Bernhard and K{\"a}stner, Christian},
+	author = {Apel, Sven and Lengauer, Christian and M{\"o}ller, Bernhard and K{\"a}stner, Christian},
 	title = {{An Algebraic Foundation for Automatic Feature-Based Program Synthesis}},
 	journal = SCP,
 	volume = {75},
@@ -9905,7 +10133,7 @@ Ricardo and Zimmerman, Daniel M. and Corn\'elio, M\'arcio and Th\"um, Thomas},
 @inproceedings{BDH:FoVeOOS10,
 	author = {Bubel, Richard and Din, Crystal and H{\"a}hnle, Reiner},
 	title = {{Verification of Variable Software: An Experience Report}},
-	booktitle =	FoVeOOS,
+	booktitle = FoVeOOS,
 	location = {Paris, France},
 	publisher = {Technical Report 2010-13, Department of Informatics, Karlsruhe Institute of Technology},
 	address = {Karlsruhe, Germany},
@@ -10121,7 +10349,7 @@ Ricardo and Zimmerman, Daniel M. and Corn\'elio, M\'arcio and Th\"um, Thomas},
 	address = Washington,
 	tt-tags = {SPL Testing},
 	tc-tags = {classified by Sven+Thomas,testing,sample-based analysis,family-based specification,composition-based implementation,source code / program,subsumed by none},
-	sampling-tags = {name=Alloy-based sampling,feature model,greedy,t-wise coverage,evaluation,testing efficiency,effectiveness,unavailable tool,testing,SPLC18},
+	sampling-tags = {name = Alloy-based sampling,feature model,greedy,t-wise coverage,evaluation,testing efficiency,effectiveness,unavailable tool,testing,SPLC18},
 	month = APR,
 	year = 2010,
 }
@@ -10193,7 +10421,7 @@ Ricardo and Zimmerman, Daniel M. and Corn\'elio, M\'arcio and Th\"um, Thomas},
 	pages = {196-210},
 	tt-tags = {SPL Testing},
 	tc-tags = {classified by Sven+Thomas,testing,sample-based analysis,specification undefined (none),implementation independent,source code / program,subsumed by none},
-	sampling-tags = {name=MoSo-PoLiTe,greedy,semi-automatic selection,feature model,expert knowledge,pair-wise coverage,sampling efficiency,testing efficiency,unavailable tool,evaluation,testing,SPLC18,SAT},
+	sampling-tags = {name = MoSo-PoLiTe,greedy,semi-automatic selection,feature model,expert knowledge,pair-wise coverage,sampling efficiency,testing efficiency,unavailable tool,evaluation,testing,SPLC18,SAT},
 	year = 2010
 }
 
@@ -10466,15 +10694,15 @@ Ricardo and Zimmerman, Daniel M. and Corn\'elio, M\'arcio and Th\"um, Thomas},
 }
 
 @article{BDGG:NC09,
-	author={Bianchi, Leonora and Dorigo, Marco and Gambardella, LucaMaria and Gutjahr, WalterJ.},
-	title={{A Survey on Metaheuristics for Stochastic Combinatorial Optimization}},
-	issn={1567-7818},
-	journal={Natural Computing},
-	volume={8},
-	number={2},
-	publisher={Springer Netherlands},
-	pages={239-287},
-	year=2009
+	author = {Bianchi, Leonora and Dorigo, Marco and Gambardella, LucaMaria and Gutjahr, WalterJ.},
+	title = {{A Survey on Metaheuristics for Stochastic Combinatorial Optimization}},
+	issn = {1567-7818},
+	journal = {Natural Computing},
+	volume = {8},
+	number = {2},
+	publisher = {Springer Netherlands},
+	pages = {239-287},
+	year = 2009
 }
 
 @InProceedings{ACLF:SLE09,
@@ -10489,14 +10717,14 @@ Ricardo and Zimmerman, Daniel M. and Corn\'elio, M\'arcio and Th\"um, Thomas},
 }
 
 @inproceedings{YD:NaBIC09, 
-	author= {Yang, Xin-She and Deb, S.}, 
-	title={{Cuckoo Search via Levy Flights}},
+	author = {Yang, Xin-She and Deb, S.}, 
+	title = {{Cuckoo Search via Levy Flights}},
 	booktitle = NaBIC,  
 	publisher = IEEE,
-	pages= {210-214}, 
-	mu-tags={-read, algorithm theory,Cuckoo search,optimization}, 
-	doi={10.1109/NABIC.2009.5393690},
-	year=2009
+	pages = {210-214}, 
+	mu-tags = {-read, algorithm theory,Cuckoo search,optimization}, 
+	doi = {10.1109/NABIC.2009.5393690},
+	year = 2009
 }
 
 
@@ -11029,7 +11257,7 @@ Ricardo and Zimmerman, Daniel M. and Corn\'elio, M\'arcio and Th\"um, Thomas},
 @inproceedings{HM:WCRE08,
 	author = {Masatomo Hashimoto and Akira Mori},
 	booktitle = WCRE,
-	title={{Diff/TS: A Tool for Fine-Grained Structural Change Analysis}},
+	title = {{Diff/TS: A Tool for Fine-Grained Structural Change Analysis}},
 	year = {2008},
 	pages = {279--288},
 	pb-tags = {tree differencing},
@@ -11042,7 +11270,7 @@ Ricardo and Zimmerman, Daniel M. and Corn\'elio, M\'arcio and Th\"um, Thomas},
 	author = {{\O}ystein Haugen and Birger M{\o}ller-Pedersen and Jon Oldevik and G{\o}ran K. Olsen and Andreas Svendsen},
 	booktitle = SPLC,
 	pages = {139--148},
-	organization = {IEEE},
+	publisher = IEEE,
 	tt-tags = {Feature-Modeling Language,CVL,Download},
 	year = 2008
 } 
@@ -11109,14 +11337,14 @@ Ricardo and Zimmerman, Daniel M. and Corn\'elio, M\'arcio and Th\"um, Thomas},
 }
 
 @INPROCEEDINGS{AT:ISSRE08, 
-	author={Anbalagan, P. and Tao Xie}, 
-	title={{Automated Generation of Pointcut Mutants for Testing Pointcuts in AspectJ Programs}}, 
-	booktitle=ISSRE, 
-	month={Nov}, 
-	pages={239-248}, 
-	doi={10.1109/ISSRE.2008.58}, 
-	ISSN={1071-9458},
-	year=2008
+	author = {Anbalagan, P. and Tao Xie}, 
+	title = {{Automated Generation of Pointcut Mutants for Testing Pointcuts in AspectJ Programs}}, 
+	booktitle = ISSRE, 
+	month = {Nov}, 
+	pages = {239-248}, 
+	doi = {10.1109/ISSRE.2008.58}, 
+	ISSN = {1071-9458},
+	year = 2008
 }
 
 @inproceedings{DKN+:WCRE08,
@@ -11227,7 +11455,7 @@ Ricardo and Zimmerman, Daniel M. and Corn\'elio, M\'arcio and Th\"um, Thomas},
 	address = Washington,
 	tt-tags = {},
 	tc-tags = {},
-	sampling-tags = {name=AETG-SAT, testing efficiency, sampling efficiency, greedy, compares four variations of AETG-SAT, CCIT, testing, feature model,t-wise coverage, unavailable tool, evaluation, JS20},
+	sampling-tags = {name = AETG-SAT, testing efficiency, sampling efficiency, greedy, compares four variations of AETG-SAT, CCIT, testing, feature model,t-wise coverage, unavailable tool, evaluation, JS20},
 	year = 2008
 }
 
@@ -11702,8 +11930,8 @@ Ricardo and Zimmerman, Daniel M. and Corn\'elio, M\'arcio and Th\"um, Thomas},
 
 @inproceedings{RK:D07,
 	author = {Rainer Koschke},
-	title =	{{Survey of Research on Software Clones}},
-	booktitle =	{{Duplication, Redundancy, and Similarity in Software}},
+	title = {{Survey of Research on Software Clones}},
+	booktitle = {{Duplication, Redundancy, and Similarity in Software}},
 	year = 2007,
 	editor = {Rainer Koschke and Ettore Merlo and Andrew Walenstein},
 	number = {06301},
@@ -11733,7 +11961,7 @@ Ricardo and Zimmerman, Daniel M. and Corn\'elio, M\'arcio and Th\"um, Thomas},
 
 
 @ARTICLE{PGM+:TSE07,
-	author={Denys {Poshyvanyk} and Yann-Gael {Gueheneuc} and Andrian {Marcus} and Giuliano {Antoniol} and Vaclav {Rajlich}},
+	author = {Denys {Poshyvanyk} and Yann-Gael {Gueheneuc} and Andrian {Marcus} and Giuliano {Antoniol} and Vaclav {Rajlich}},
 	journal = TSE,
 	publisher = IEEE,
 	title = {{Feature Location Using Probabilistic Ranking of Methods Based on Execution Scenarios and Information Retrieval}},
@@ -11774,13 +12002,13 @@ Ricardo and Zimmerman, Daniel M. and Corn\'elio, M\'arcio and Th\"um, Thomas},
 }
 
 @INPROCEEDINGS{FW:WMA07, 
-	author={Fraser, G. and Wotawa, F.}, 
-	title={{Mutant Minimization for Model-Checker Based Test-Case Generation}}, 
-	booktitle={in Proc. of Workshop on Mutation Analysis, Published with Proc. of Testing: Academic and Industrial Conference Practice and Research Techniques}, 
-	month=SEP, 
-	pages={161-168}, 
-	doi={10.1109/TAIC.PART.2007.30},
-	year=2007
+	author = {Fraser, G. and Wotawa, F.}, 
+	title = {{Mutant Minimization for Model-Checker Based Test-Case Generation}}, 
+	booktitle = {in Proc. of Workshop on Mutation Analysis, Published with Proc. of Testing: Academic and Industrial Conference Practice and Research Techniques}, 
+	month = SEP, 
+	pages = {161-168}, 
+	doi = {10.1109/TAIC.PART.2007.30},
+	year = 2007
 }
 
 @inproceedings{BCU:FMOODS07,
@@ -11800,7 +12028,7 @@ Ricardo and Zimmerman, Daniel M. and Corn\'elio, M\'arcio and Th\"um, Thomas},
 @inproceedings{BC:CGEC07,
  	author = {Bryce, Ren{\'e}e C. and Colbourn, Charles J.},
 	 title = {{One-test-at-a-time Heuristic Search for Interaction Test Suites}},
- 	booktitle =GECCO,
+ 	booktitle = GECCO,
  	  isbn = {978-1-59593-697-4},
 	 location = {London, England},
 	 pages = {1082--1089},
@@ -11881,11 +12109,11 @@ Ricardo and Zimmerman, Daniel M. and Corn\'elio, M\'arcio and Th\"um, Thomas},
 }
 
 @article{NCB+SEI07,
-  	author={Northrop, Linda and Clements, P.},
-  	title={{A Framework for Software Product Line Practice, Version 5.0}},
- 	 journal={SEI},
-	address =  {Pittsburgh,USA},
-  	year=2007
+  	author = {Northrop, Linda and Clements, P.},
+  	title = {{A Framework for Software Product Line Practice, Version 5.0}},
+ 	journal = {SEI},
+	address = {Pittsburgh,USA},
+  	year = 2007
 }
 
 @inproceedings{CDS:ISSTA07,
@@ -12338,14 +12566,14 @@ of Passau},
 } 
 
 @INPROCEEDINGS{D:QSIC06, 
-	author={Derezinska, A.}, 
-	title={{Quality Assessment of Mutation Operators Dedicated for C\# Programs}}, 
-	booktitle=QSIC, 
-	month={Oct}, 
-	pages={227-234}, 
-	doi={10.1109/QSIC.2006.51}, 
-	ISSN={1550-6002},
-	year=2006
+	author = {Derezinska, A.}, 
+	title = {{Quality Assessment of Mutation Operators Dedicated for C\# Programs}}, 
+	booktitle = QSIC, 
+	month = {Oct}, 
+	pages = {227-234}, 
+	doi = {10.1109/QSIC.2006.51}, 
+	ISSN = {1550-6002},
+	year = 2006
 }
 
 @book{UL06,
@@ -13337,7 +13565,7 @@ of Passau},
 	pages = {2--13},
 	year = 2004,
 	doi = {10.1109/ASE.2004.10015},
-	organization = IEEE,
+	publisher = IEEE,
 	address = Washington,
 	as-tags = {program diffing}
 }
@@ -13376,8 +13604,8 @@ of Passau},
 	pages = {394--403},
 	doi = {10.1287/inte.1040.0092},
 	acmid = {1045697},
-	publisher = {INFORMS},
-	address = {Institute for Operations Research and the Management Sciences (INFORMS), Linthicum, Maryland, USA},
+	publisher = INFORMS,
+	address = Linthium,
 	keywords = {Inventory: production, policies, ordering, Manufacturing: strategy},
 	tt-tags = {Configuration},
 	month = OCT,
@@ -13455,7 +13683,7 @@ of Passau},
 @article{M:STVR04,
 	author = {McMinn, Phil},
 	title = {{Search-Based Software Test Data Generation: A Survey: Research Articles}},
-	journal =STVR,
+	journal = STVR,
 	volume = {14},
 	number = {2},
 	issn = {0960-0833},
@@ -13701,8 +13929,8 @@ of Passau},
 
 @inproceedings{BHST04,
   author = {Yves Bontemps and Patrick Heymans and Pierre-Yves Schobbens and Jean-Christophe Trigaux},
-  title =	{{Semantics of Feature Diagrams}},
-  booktitle =	SVMPD,
+  title = {{Semantics of Feature Diagrams}},
+  booktitle = SVMPD,
 	tt-tags = {},
   year = 2004
 }
@@ -13752,7 +13980,7 @@ of Passau},
 	booktitle = PFE,
 	pages = {211--224},
 	isbn = {3-540-21941-2},
-	doi       = {10.1007/978-3-540-24667-1_16},
+	doi = {10.1007/978-3-540-24667-1_16},
 	publisher = Springer,
 	address = BerlinHeidelberg,
 	tc-tags = {classified by Ina,feature-model analysis,subsumed by none},
@@ -13766,7 +13994,7 @@ of Passau},
 	booktitle = PFE,
 	pages = {181--197},
 	isbn = {3-540-21941-2},
-	doi       = {10.1007/978-3-540-24667-1_14},
+	doi = {10.1007/978-3-540-24667-1_14},
 	publisher = Springer,
 	address = BerlinHeidelberg,
 	tc-tags = {classified by Thomas,testing,unoptimized product-based analysis,feature-based specification? family-based specification?,subsumed by none},
@@ -13785,7 +14013,7 @@ of Passau},
 }
 
 @inproceedings{H:JMLC03,
-	author={Hoare, C. A. R.},
+	author = {Hoare, C. A. R.},
 	title = {{The Verifying Compiler: A Grand Challenge for Computing Research}},
 	booktitle = JMLC,
 	pages = {25-35},
@@ -13850,14 +14078,14 @@ of Passau},
 }
 
 @inproceedings{SDNB:ECOOP03,
-	author={Sch{\"a}rli, Nathanael and Ducasse, St{\'e}phane and Nierstrasz, Oscar and Black, Andrew P.},
+	author = {Sch{\"a}rli, Nathanael and Ducasse, St{\'e}phane and Nierstrasz, Oscar and Black, Andrew P.},
 	title = {{Traits: Composable Units of Behaviour}},
 	booktitle = ECOOP,
 	isbn = {978-3-540-40531-3},
 	doi = {10.1007/978-3-540-45070-2_12},
 	publisher = Springer,
 	address = BerlinHeidelberg,
-	pages={248-274},
+	pages = {248-274},
 	tt-tags = {Modularity,Traits},
 	year = 2003
 }
@@ -14111,7 +14339,7 @@ Stories of successful software product line deployments often read like epic adv
 @article{KLD:Software02,
 	author = {Kyo C. Kang and Jaejoon Lee and Patrick Donohoe},
 	title = {{Feature-Oriented Product Line Engineering}},
-	journal =Software,
+	journal = Software,
 	volume = {19},
 	number = {4},
 	issn = {0740-7459},
@@ -14449,7 +14677,7 @@ Stories of successful software product line deployments often read like epic adv
   	title = {{Testing a Software Product Line}},
 	institution = {Carnegie Mellon University},
 	number = {CMU/SEI-2001-TR-022 },
- 	year=2001
+ 	year = 2001
 }
 
 
@@ -14659,7 +14887,7 @@ Stories of successful software product line deployments often read like epic adv
 	booktitle = IWPC,
 	isbn = {0-7695-0656-9},
 	pages = {241--249},
-	url = {http://dl.acm.org/citation.cfm?id=518049.856972},
+	url = {http://dl.acm.org/citation.cfm?id = 518049.856972},
 	acmid = {856972},
 	publisher = IEEE,
 	address = Washington,
@@ -14692,7 +14920,7 @@ Stories of successful software product line deployments often read like epic adv
  	pages = {102--112},
 	 numpages = {11},
  	publisher = ACM,
- 	address =  NY,
+ 	address = NY,
 	 year = 2000
 } 
 
@@ -14930,6 +15158,15 @@ Stories of successful software product line deployments often read like epic adv
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% 1998 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
+@book{MT98,
+	title = {{Algorithms and Data Structures in VLSI Design: OBDD-Foundations and Applications}},
+	author = {Meinel, Christoph and Theobald, Thorsten},
+	volume = {1},
+	publisher = Springer,
+	address = BerlinHeidelberg,
+	year = 1998,
+}
+
 @book{SP98,
 	author = {Uwe Sch{\"{o}}ning and Randall Pruim},
 	title = {{Gems of Theoretical Computer Science}},
@@ -14966,16 +15203,16 @@ Stories of successful software product line deployments often read like epic adv
 }
 
 @article{JZ:TSE98, 
-	author={Jackson, Michael  and Zave, Pamela }, 
-	title={{Distributed feature composition: a virtual architecture for telecommunications services}}, 
-	journal=TSE, 
-	month={Oct}, 
-	volume={24}, 
-	number={10}, 
-	pages={831-847}, 
-	doi={10.1109/32.729683}, 
-	ISSN={0098-5589},
-	year=1998
+	author = {Jackson, Michael  and Zave, Pamela }, 
+	title = {{Distributed feature composition: a virtual architecture for telecommunications services}}, 
+	journal = TSE, 
+	month = {Oct}, 
+	volume = {24}, 
+	number = {10}, 
+	pages = {831-847}, 
+	doi = {10.1109/32.729683}, 
+	ISSN = {0098-5589},
+	year = 1998
 }
 
 @inproceedings{K:TOOLS98,
@@ -15277,7 +15514,7 @@ Stories of successful software product line deployments often read like epic adv
 	booktitle = CAV,
 	isbn = {978-3-540-61474-6},
 	doi = {10.1007/3-540-61474-5_91},
-	pages={411-414},
+	pages = {411-414},
 	publisher = Springer,
 	address = BerlinHeidelberg,
 	tt-tags = {Model Checking,Theorem Proving},
@@ -15697,11 +15934,11 @@ Stories of successful software product line deployments often read like epic adv
 } 
 
 @book{B:Van90,
-	author={{Beizer, Boris}},
-  	title={Software Testing Techniques},
- 	publisher={Van Nostrand Reinhold},
+	author = {{Beizer, Boris}},
+  	title = {Software Testing Techniques},
+ 	publisher = {Van Nostrand Reinhold},
 	address = NY,
- 	year=1990
+ 	year = 1990
 }
 
 @book{J90,
@@ -15726,13 +15963,13 @@ Stories of successful software product line deployments often read like epic adv
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% < 1990 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 @techreport{RDH+:PU89,
- 	 author={Richard, Hiralal Agrawal and Demillo, Richard A and Hathaway, Bob and Hsu, William and Hsu, Wynne and Krauser, EW and Martin, RJ and Mathur, Aditya P and Spafford, Eugene H},
- 	 title={{Design Of Mutant Operators For The C Programming Language}},
+ 	 author = {Richard, Hiralal Agrawal and Demillo, Richard A and Hathaway, Bob and Hsu, William and Hsu, Wynne and Krauser, EW and Martin, RJ and Mathur, Aditya P and Spafford, Eugene H},
+ 	 title = {{Design Of Mutant Operators For The C Programming Language}},
 	institution = {Purdue University},
  	 number = {SERC-TR-41-P},
 	address = {West Lafayette, Indiana},
 	month = MAR,
-	year=1989
+	year = 1989
 }
 
 @inproceedings{BDC+:SETSS89,
@@ -16006,14 +16243,14 @@ Stories of successful software product line deployments often read like epic adv
 }
 
 @article{C:MOR79,
-	author={Chvatal, Vasek},
-  	title={{A Greedy Heuristic for the Set-Covering Problem}},
-    	journal={Mathematics of operations research},
-  	volume={4},
-  	number={3},
-  	pages={233--235},
-	publisher={INFORMS},
-  	year=1979
+	author = {Chvatal, Vasek},
+  	title = {{A Greedy Heuristic for the Set-Covering Problem}},
+    	journal = {Mathematics of operations research},
+  	volume = {4},
+  	number = {3},
+  	pages = {233--235},
+	publisher = {INFORMS},
+  	year = 1979
 }
 
 @inproceedings{P:ICSE78,
@@ -16336,14 +16573,14 @@ Stories of successful software product line deployments often read like epic adv
 }
 
 @article{H:BST50,
-	author={Hamming, Richard W},
-	title={Error detecting and error correcting codes},
-	journal={Bell System technical journal},
-	volume={29},
-	number={2},
-	pages={147--160},
-	publisher={Wiley Online Library},
-	year=1950,
+	author = {Hamming, Richard W},
+	title = {Error detecting and error correcting codes},
+	journal = {Bell System technical journal},
+	volume = {29},
+	number = {2},
+	pages = {147--160},
+	publisher = {Wiley Online Library},
+	year = 1950,
 	
 }
 @inproceedings{T49,
@@ -16366,16 +16603,16 @@ Stories of successful software product line deployments often read like epic adv
 }
 
 @ARTICLE{KMSL:CDT83, 
-	author={Kramer, J. and Magee, J. and Sloman, M. and Lister, A.}, 
-	title={{CONIC: An Integrated Approach to Distributed Computer Control Systems}}, 
-	journal={IEE Proc. Computers and Digital Techniques}, 
-	month=JAN, 
-	volume={130}, 
-	number={1}, 
-	pages={1-}, 
-	doi={10.1049/ip-e.1983.0001}, 
-	ISSN={0143-7062},
-	year=1983
+	author = {Kramer, J. and Magee, J. and Sloman, M. and Lister, A.}, 
+	title = {{CONIC: An Integrated Approach to Distributed Computer Control Systems}}, 
+	journal = {IEE Proc. Computers and Digital Techniques}, 
+	month = JAN, 
+	volume = {130}, 
+	number = {1}, 
+	pages = {1-}, 
+	doi = {10.1049/ip-e.1983.0001}, 
+	ISSN = {0143-7062},
+	year = 1983
 }
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% MISC %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
* Added abrv from Chico's paper

* Added literature from 2016

* Added literature from 2015 and missing abrvs to MYshort

* Added literature from 2014

* Added literature from 2013

* Fixed missing double brackets and order

* Added literature for 2012 and fixed some bibtex mistakes (organisation -> publisher)

* Fixed PR

* Fixed missing double brackets in LCF+:TASE12

* Unified the spacing to from `\s*=\s*` to `\s=\s`